### PR TITLE
[FBZ10258] Migrate sudo recipe

### DIFF
--- a/cookbooks/ey-dynamic/recipes/user.rb
+++ b/cookbooks/ey-dynamic/recipes/user.rb
@@ -58,4 +58,10 @@ node["dna"]["users"].each do |user_obj|
   execute "chown homedir to user" do
     command "chown -R #{user_obj['username']}:#{user_obj['username']} /data/homedirs/#{user_obj['username']}"
   end
+
+  sudo "ey-managed-dymaic-sudoers" do
+    users user_obj["username"]
+    group user_obj["username"]
+    nopasswd true
+  end
 end


### PR DESCRIPTION
This is to migrate the sudo recipe in actual fact rather than create a whole new recipe we just use the sudo functionality in chef to have a more minimised and updated experience 

V6 original: https://github.com/engineyard/ey-cookbooks-stable-v6/blob/next-release/cookbooks/sudo/