### PR TITLE
[FBZ-10418] Lets Encrypt recipe doesn't distribute/renew wildcard certificates

### DIFF
--- a/cookbooks/ey-letsencrypt/templates/check_le.sh.erb
+++ b/cookbooks/ey-letsencrypt/templates/check_le.sh.erb
@@ -33,7 +33,7 @@ alert ()
 
 
 
-if [[ $(sudo openssl x509 -in /etc/letsencrypt/live/<%= @md %>/cert.pem -checkend 604800 -noout |grep "Certificate will expire" --ignore-case) ]]; then
+if [[ $(sudo openssl x509 -in /etc/letsencrypt/live/<%= @md.sub('*.', '') %>/cert.pem -checkend 604800 -noout |grep "Certificate will expire" --ignore-case) ]]; then
   alert "Certificate is invalid" "FAILURE"
 else
   alert "Certificate is valid" "OKAY"

--- a/cookbooks/ey-letsencrypt/templates/copycerts.sh.erb
+++ b/cookbooks/ey-letsencrypt/templates/copycerts.sh.erb
@@ -1,10 +1,10 @@
 #!/bin/bash
 instances='<%= @instances %>'
 appname='<%= @app_name %>'
-md='<%= @md %>'
+md=<%= @md.sub('*.', '') %>
 ssh_options='ssh -i /root/.ssh/internal -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10'
 
-source /data/${appname}/shared/config/env.coud
+source /data/${appname}/shared/config/env.cloud
 
 if [[ $(find "/etc/letsencrypt/live/${md}/fullchain.pem" -mtime +30 -print)  ]]; then
 


### PR DESCRIPTION
Modified scripts below:

* `ey-letsencrypt/templates/check_le.sh.erb`
* `ey-letsencrypt/templates/copycerts.sh.erb`

and updated `<%= @md %>` to `<%= @md.sub('*.', '') %>` in order to remove wildcard when the scripts mentioned are looking for the folder.

Corrected `source /data/${appname}/shared/config/env.coud` to `source /data/${appname}/shared/config/env.cloud` in `ey-letsencrypt/templates/copycerts.sh.erb`