### PR TITLE
[FBZ-10429] Migrate PostgreSQL Maintenance Recipe to v7

### DIFF
--- a/cookbooks/ey-postgresql_maintenance/README.md
+++ b/cookbooks/ey-postgresql_maintenance/README.md
@@ -1,0 +1,10 @@
+postgresql_maintenance
+------------------------------------------------------------------------------
+
+A chef recipe for enabling maintenance tasks for Postgresql on Engine Yard Cloud. 
+
+The postgresql_maintenance recipe is managed by Engine Yard. You should not copy this recipe to your repository but instead copy `custom-postgresql_maintenance`. Please check the [custom-postgresql_maintenance readme](../../custom-cookbooks/postgresql_maintenance/cookbooks/custom-postgresql_maintenance) for the complete instructions.
+
+We accept contributions for changes that can be used by all customers.
+
+

--- a/cookbooks/ey-postgresql_maintenance/attributes/default.rb
+++ b/cookbooks/ey-postgresql_maintenance/attributes/default.rb
@@ -1,0 +1,9 @@
+default["postgresql_maintenance"]["vacuumdb_cron_minute"] = "0"
+default["postgresql_maintenance"]["vacuumdb_cron_hour"] = "0"
+default["postgresql_maintenance"]["vacuumdb_cron_day"] = "*"
+default["postgresql_maintenance"]["vacuumdb_cron_month"] = "*"
+default["postgresql_maintenance"]["vacuumdb_cron_weekday"] = "0"
+
+# this will vacuum all dbs
+default["postgresql_maintenance"]["vacuumdb_command"] = "/usr/bin/vacuumdb -U postgres --all"
+

--- a/cookbooks/ey-postgresql_maintenance/metadata.rb
+++ b/cookbooks/ey-postgresql_maintenance/metadata.rb
@@ -1,0 +1,2 @@
+name "ey-postgresql_maintenance"
+version "1.0.0"

--- a/cookbooks/ey-postgresql_maintenance/recipes/default.rb
+++ b/cookbooks/ey-postgresql_maintenance/recipes/default.rb
@@ -1,0 +1,12 @@
+
+# Sets a default schedule of Midnight system time Sunday for a vacuum
+if node["dna"]["instance_role"][/^db_master|solo/] && node["dna"]["engineyard"]["environment"]["db_stack_name"][/^postgres/]
+  cron "manual_vacuumdb" do
+    minute  node["postgresql_maintenance"]["vacuumdb_cron_minute"]
+    hour    node["postgresql_maintenance"]["vacuumdb_cron_hour"]
+    day     node["postgresql_maintenance"]["vacuumdb_cron_day"]
+    month   node["postgresql_maintenance"]["vacuumdb_cron_month"]
+    weekday node["postgresql_maintenance"]["vacuumdb_cron_weekday"]
+    command node["postgresql_maintenance"]["vacuumdb_command"]
+  end
+end

--- a/custom-cookbooks/postgresql_maintenance/README.md
+++ b/custom-cookbooks/postgresql_maintenance/README.md
@@ -1,0 +1,7 @@
+# PostgreSQL Maintenance
+
+This example contains a `cookbooks/` directory to consume the postgresql_maintenance cookbook for
+the V6 stack.
+
+See [cookbooks/postgresql_maintenance](cookbooks/custom-postgresql_maintenance/README.md) for complete
+instructions.

--- a/custom-cookbooks/postgresql_maintenance/cookbooks/custom-postgresql_maintenance/README.md
+++ b/custom-cookbooks/postgresql_maintenance/cookbooks/custom-postgresql_maintenance/README.md
@@ -1,0 +1,76 @@
+# custom-postgresql_maintenance
+
+This is a wrapper cookbook around Engine Yard's `ey-postgresql_maintenance` cookbook. Currently this recipe consists of setting up a vacuumdb cron job for a PostgreSQL database that can be customized to a specific application need (see below). This recipe may be updated in the future to support additional maintenance options.
+
+
+Dependencies
+--------------------------
+
+These recipes are designed and build for use with PostgreSQL.
+
+
+
+
+## Installation
+
+For simplicity, we recommend that you create the cookbooks directory at the root
+of your application. If you prefer to keep the infrastructure code separate from
+application code, you can create a new repository.
+
+Our main cookbook have the `ey-postgresql_maintenance` cookbook but it is not included by default.
+To use the `ey-postgresql_maintenance` cookbook, you should copy this cookbook, `custom-postgresql_maintenance`.
+You should not copy the actual `postgresql_maintenance` recipe. That is managed by Engine
+Yard.
+
+1. Edit `cookbooks/ey-custom/recipes/after-main.rb` and add
+
+  ```
+  include_recipe 'custom-postgresql_maintenance'
+  ```
+
+2. Edit `cookbooks/ey-custom/metadata.rb` and add
+
+  ```
+  depends 'custom-postgresql_maintenance'
+  ```
+
+3. Copy `custom-cookbooks/packages/cookbooks/custom-postgresql_maintenance` to `cookbooks/`
+
+  ```
+  cd ~ # Change this to your preferred directory. Anywhere but inside the application
+
+  git clone https://github.com/engineyard/ey-cookbooks-stable-v7
+  cd ey-cookbooks-stable-v7
+  cp custom-cookbooks/packages/cookbooks/custom-postgresql_maintenance /path/to/app/cookbooks/
+  ```
+
+4. Download the ey-core gem on your local machine and upload the recipes
+
+  ```
+  gem install ey-core
+  ey-core recipes upload --environment=<nameofenvironment> --file=<pathtocookbooksfilder> --apply
+  ```
+
+VacuumDB
+--------------------------
+
+Your database is configured by default with autovacuum but minimizes resources to this process to prevent it from negatively impacting application performance. Databases that see regular heavy load, or lots of writes and deletes may need regular manual vacuum operations globally or for specific tables.
+
+The default action for the recipe will set up a weekly vacuum of all databases on the server at midnight Saturday night/Sunday morning server time.
+
+Additional information on vacuum operation can be found in the PostgreSQL Manual: https://www.postgresql.org/docs/10/sql-vacuum.html.
+
+## Customizations
+
+All customizations go to `cookbooks/custom-postgresql_maintenance/attributes/default.rb`.
+
+```
+default["postgresql_maintenance"]["vacuumdb_cron_minute"] = "0"
+default["postgresql_maintenance"]["vacuumdb_cron_hour"] = "0"
+default["postgresql_maintenance"]["vacuumdb_cron_day"] = "*"
+default["postgresql_maintenance"]["vacuumdb_cron_month"] = "*"
+default["postgresql_maintenance"]["vacuumdb_cron_weekday"] = "0"
+
+# this will vacuum all dbs
+default["postgresql_maintenance"]["vacuumdb_command"] = "/usr/bin/vacuumdb -U postgres --all"
+```

--- a/custom-cookbooks/postgresql_maintenance/cookbooks/custom-postgresql_maintenance/attributes/default.rb
+++ b/custom-cookbooks/postgresql_maintenance/cookbooks/custom-postgresql_maintenance/attributes/default.rb
@@ -1,0 +1,8 @@
+# default["postgresql_maintenance"]["vacuumdb_cron_minute"] = "0"
+# default["postgresql_maintenance"]["vacuumdb_cron_hour"] = "0"
+# default["postgresql_maintenance"]["vacuumdb_cron_day"] = "*"
+# default["postgresql_maintenance"]["vacuumdb_cron_month"] = "*"
+# default["postgresql_maintenance"]["vacuumdb_cron_weekday"] = "0"
+#
+# # this will vacuum all dbs
+# default["postgresql_maintenance"]["vacuumdb_command"] = "/usr/bin/vacuumdb -U postgres --all"

--- a/custom-cookbooks/postgresql_maintenance/cookbooks/custom-postgresql_maintenance/metadata.rb
+++ b/custom-cookbooks/postgresql_maintenance/cookbooks/custom-postgresql_maintenance/metadata.rb
@@ -1,0 +1,3 @@
+name "custom-postgresql_maintenance"
+version "1.0.0"
+depends "ey-postgresql_maintenance"

--- a/custom-cookbooks/postgresql_maintenance/cookbooks/custom-postgresql_maintenance/recipes/default.rb
+++ b/custom-cookbooks/postgresql_maintenance/cookbooks/custom-postgresql_maintenance/recipes/default.rb
@@ -1,0 +1,1 @@
+include_recipe "ey-postgresql_maintenance"

--- a/custom-cookbooks/postgresql_maintenance/cookbooks/ey-custom/metadata.rb
+++ b/custom-cookbooks/postgresql_maintenance/cookbooks/ey-custom/metadata.rb
@@ -1,0 +1,3 @@
+name "ey-custom"
+version "1.0.0"
+depends "custom-postgresql_maintenance"

--- a/custom-cookbooks/postgresql_maintenance/cookbooks/ey-custom/recipes/after-main.rb
+++ b/custom-cookbooks/postgresql_maintenance/cookbooks/ey-custom/recipes/after-main.rb
@@ -1,0 +1,1 @@
+include_recipe "custom-postgresql_maintenance"


### PR DESCRIPTION
**Description of your patch**
Migrate PostgreSQL Maintenance Recipe from v6 to v7

**Recommended Release Notes**
Adds support for PostgreSQL Maintenance which adds a scheduled job

**Estimated risk**
Low risk

**Components involved**
Own components

**Dependencies**
Stack must be using PostgreSQL

**Description of testing done**
* Create a fresh environment with PostgreSQL as DB
* Enable PostgreSQL Maintenance
* Upload the custom script and apply to the environment
* Check the postgresql maintenance cronjob via `crontab -l`
* Should be named as `manual_vacuumdb`

**QA Instructions**
* Create a fresh environment with PostgreSQL as DB
* Enable PostgreSQL Maintenance
* Upload the custom script and apply to the environment
* Check the postgresql maintenance cronjob via `crontab -l`
* Should be named as `manual_vacuumdb`