### PR TITLE
[FBZ10440] Fix #94: NGINX with HTTP2 requires SSL

### DIFF
--- a/cookbooks/ey-nginx/attributes/default.rb
+++ b/cookbooks/ey-nginx/attributes/default.rb
@@ -1,5 +1,5 @@
 default["nginx"]["action"] = node.engineyard.metadata(:nginx_action, :restart)
-default["nginx"]["http2"] = false
+default["nginx"]["http2"] = fetch_env_var(node, "EY_HTTP2_ENABLED") =~ /^TRUE$/i
 default["nginx"]["systemd_mask"] = ["app_master", "app", "solo"].include?(node["dna"]["instance_role"]) ? false : true
 default["nginx"]["behind_proxy"] = true
 default["nginx"]["nginx_haproxy_http_port"] = 8091

--- a/cookbooks/ey-nginx/recipes/php.rb
+++ b/cookbooks/ey-nginx/recipes/php.rb
@@ -16,7 +16,7 @@ node.engineyard.apps.each_with_index do |app, _index|
         haproxy_nginx_port: !(count == 0) ? node["nginx"]["nginx_haproxy_https_port"] : node["nginx"]["nginx_haproxy_http_port"],
         xlb_nginx_port: !(count == 0) ? node["nginx"]["nginx_xlb_https_port"] : node["nginx"]["nginx_xlb_http_port"],
         app_instance: is_app_master,
-        http2: node["nginx"]["http2"],
+        http2: !(count == 0) && node["nginx"]["http2"],
         ssl: !(count == 0)
       )
       notifies node["nginx"]["action"], "service[nginx]", :delayed

--- a/cookbooks/ey-nginx/recipes/ruby.rb
+++ b/cookbooks/ey-nginx/recipes/ruby.rb
@@ -31,7 +31,7 @@ node.engineyard.apps.each_with_index do |app, index|
         xlb_nginx_port: !(count == 0) ? node["nginx"]["nginx_xlb_https_port"] : node["nginx"]["nginx_xlb_http_port"],
         app_instance: is_app_master,
         upstream_port: ports,
-        http2: node["nginx"]["http2"],
+        http2: !(count == 0) && node["nginx"]["http2"],
         ssl: !(count == 0)
       )
       notifies :restart, "service[nginx]", :delayed


### PR DESCRIPTION
Description of your patch
-------------

Fixes a regression in HTTPS2 configuration for NGINX caused by combining the recipe blocks for http and https in the updated EY-7 nginx recipe, and adds an environmental variable for enabling to make testing easier.

Recommended Release Notes
-------------

* Add environmental variable EY_HTTP2_ENABLED for enabling HTTP2

Estimated risk
-------------

Low – this resolves a regression from EY-6 and adds a configuration variable so that a custom overlay is not required

Components involved
-------------

ey-nginx

Dependencies
-------------

None

Description of testing done
-------------

Tested on a Rails 7/Ruby 3.1 project using an overlay.

QA Instructions
-------------

1. Set EY_HTTP2_ENABLED=TRUE on a new instance
2. run apply
3. ensure that the nginx _app_.conf server block contains 

```
    listen 8091 proxy_protocol;
    listen 8081 ;
```

4. ensure that the nginx `_app_.ssl.conf` server block contains
```
    listen 8092 ssl http2 proxy_protocol;
```

5. ensure that `sudo nginx -t` does not return any errors