### PR TITLE
[FBZ-10435] - add check for env.custom in Puma_legacy

### DIFF
--- a/cookbooks/ey-puma_legacy/templates/default/app_control.erb
+++ b/cookbooks/ey-puma_legacy/templates/default/app_control.erb
@@ -13,6 +13,7 @@ cloud_env="/data/${application}/shared/config/env.cloud"
 [[ -f "${cloud_env}" ]] && source "${cloud_env}"
 
 source /etc/profile
+source /data/<%= @app_name %>/shared/config/env
 
 # Ensure that we are running as the root user.
 # If not, error exit while notifying the user.

--- a/cookbooks/ey-puma_legacy/templates/default/app_control.erb
+++ b/cookbooks/ey-puma_legacy/templates/default/app_control.erb
@@ -3,10 +3,16 @@
 
 # Pull in a full environment and include some configuration of said commands.
 
+custom_env="/data/${application}/shared/config/env.custom"
+cloud_env="/data/${application}/shared/config/env.cloud"
+
+# Load the custom env if it exists
+[[ -f "${custom_env}" ]] && source "${custom_env}"
+
+# Load the cloud env if it exists
+[[ -f "${cloud_env}" ]] && source "${cloud_env}"
+
 source /etc/profile
-source /data/<%= @app_name %>/shared/config/env
-source /data/<%= @app_name %>/shared/config/env.custom
-source /data/<%= @app_name %>/shared/config/env.cloud
 
 # Ensure that we are running as the root user.
 # If not, error exit while notifying the user.


### PR DESCRIPTION
**Description of your patch**
Add check for env.custom in Puma_legacy

**Recommended Release Notes**
Added check for  env.custom in Puma_legacy

**Estimated risk**
Low

**Components involved**

cookbooks/ey-puma_legacy/templates/default/app_control.erb

**Dependencies**

None

**Description of testing done**

Provision v7 puma_leagacy stack environment
test application restart using /engineyard/bin/app_appname restart to restart app fine without reporting missing `env.custom`

**QA Instructions**

Provision v7 stack environment
Select app stack as puma and create environment
Form AWSM change app stack to Puma_legacy
Run apply and try restarting application using /engineyard/bin/app_appname restart, this should not report missing `env.custom`