### PR TITLE
[FBZ-10452] UI cron fix for v7

### DIFF
--- a/cookbooks/ey-cron/libraries/crontab_instance.rb
+++ b/cookbooks/ey-cron/libraries/crontab_instance.rb
@@ -38,9 +38,9 @@ class Chef
 
       case crontab_instance_name
       when ""
-        true if app_master_or_solo?(node)
+        return true if app_master_or_solo?(node)
       else
-        true if utility_named?(node, crontab_instance_name)
+        return true if utility_named?(node, crontab_instance_name)
       end
 
       false


### PR DESCRIPTION
Upon testing, UI crons are not being created in v7.

We need to update `ey-cron/libraries/crontab_instance.rb` to return true for the condition `if crontab_instance?(node)` in ey-cron/recipes/ui.rb to work.

Lines 41 and 43:
From:

```
        true if app_master_or_solo?(node)
      else
        true if utility_named?(node, crontab_instance_name)
```

to:

```
        return true if app_master_or_solo?(node)
      else
        return true if utility_named?(node, crontab_instance_name)
```