### PR TITLE
[FBZ-10398] - Migrate elasticsearch cookbook to stack v7

### DIFF
--- a/cookbooks/ey-elasticsearch/README.md
+++ b/cookbooks/ey-elasticsearch/README.md
@@ -1,0 +1,7 @@
+# Elasticsearch
+
+This recipe is used to run on Elasticsearch the stable-v7 stack.
+
+The elasticsearch recipe is managed by Engine Yard. You should not copy this recipe to your repository but instead copy custom-elasticsearch. Please check the [custom-elasticsearch readme](../../custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch) for the complete instructions.
+
+We accept contributions for changes that can be used by all customers.

--- a/cookbooks/ey-elasticsearch/attributes/default.rb
+++ b/cookbooks/ey-elasticsearch/attributes/default.rb
@@ -1,37 +1,37 @@
-default['elasticsearch'].tap do |elasticsearch|
+default["elasticsearch"].tap do |elasticsearch|
   # Run Elasticsearch on util instances containing elasticsearch in name
   # This is the default
-  elasticsearch['instance_name'] = 'elasticsearch'
-  elasticsearch['is_elasticsearch_instance'] = (
-    node['dna']['instance_role'] == 'util' &&
-    node['dna']['name'].include?(elasticsearch['instance_name'])
+  elasticsearch["instance_name"] = "elasticsearch"
+  elasticsearch["is_elasticsearch_instance"] = (
+    node["dna"]["instance_role"] == "util" &&
+    node["dna"]["name"].include?(elasticsearch["instance_name"])
   )
 
   # Run Elasticsearch on a solo or app_master instance
   # Not recommended for production environments
-  #elasticsearch['is_elasticsearch_instance'] = ( ['solo', 'app_master'].include?(node['dna']['instance_role']) )
+  # elasticsearch['is_elasticsearch_instance'] = ( ['solo', 'app_master'].include?(node['dna']['instance_role']) )
 
   # Elasticsearch version to install
   # Go to https://www.elastic.co/downloads/past-releases to see the available version
-  #elasticsearch['version'] = '5.6.15'
-  elasticsearch['version'] = '6.6.3'
-  
+  # elasticsearch['version'] = '5.6.15'
+  elasticsearch["version"] = "6.6.3"
+
   # Elasticsearch cluster name
-  elasticsearch['clustername'] = node['dna']['environment']['name']
+  elasticsearch["clustername"] = node["dna"]["environment"]["name"]
 
   # Where to store the ES index
-  elasticsearch['home'] = '/data/elasticsearch'
+  elasticsearch["home"] = "/data/elasticsearch"
 
   # Elasticsearch configuration parameters
-  elasticsearch['defaultreplicas'] = 1
-  elasticsearch['defaultshards'] = 6
+  elasticsearch["defaultreplicas"] = 1
+  elasticsearch["defaultshards"] = 6
 
   # JVM Options, will be used to populate /etc/elasticsearch/jvm.options
   # For guidelines on how to calculate the optimal JVM memory settings,
   # see https://www.elastic.co/guide/en/elasticsearch/reference/master/heap-size.html
-  elasticsearch['jvm_options'] = {
-    :Xms => '2g',
-    :Xmx => '2g',
-    :Xss => '1m'
+  elasticsearch["jvm_options"] = {
+    Xms: "2g",
+    Xmx: "2g",
+    Xss: "1m",
   }
 end

--- a/cookbooks/ey-elasticsearch/attributes/default.rb
+++ b/cookbooks/ey-elasticsearch/attributes/default.rb
@@ -1,0 +1,37 @@
+default['elasticsearch'].tap do |elasticsearch|
+  # Run Elasticsearch on util instances containing elasticsearch in name
+  # This is the default
+  elasticsearch['instance_name'] = 'elasticsearch'
+  elasticsearch['is_elasticsearch_instance'] = (
+    node['dna']['instance_role'] == 'util' &&
+    node['dna']['name'].include?(elasticsearch['instance_name'])
+  )
+
+  # Run Elasticsearch on a solo or app_master instance
+  # Not recommended for production environments
+  #elasticsearch['is_elasticsearch_instance'] = ( ['solo', 'app_master'].include?(node['dna']['instance_role']) )
+
+  # Elasticsearch version to install
+  # Go to https://www.elastic.co/downloads/past-releases to see the available version
+  #elasticsearch['version'] = '5.6.15'
+  elasticsearch['version'] = '6.6.3'
+  
+  # Elasticsearch cluster name
+  elasticsearch['clustername'] = node['dna']['environment']['name']
+
+  # Where to store the ES index
+  elasticsearch['home'] = '/data/elasticsearch'
+
+  # Elasticsearch configuration parameters
+  elasticsearch['defaultreplicas'] = 1
+  elasticsearch['defaultshards'] = 6
+
+  # JVM Options, will be used to populate /etc/elasticsearch/jvm.options
+  # For guidelines on how to calculate the optimal JVM memory settings,
+  # see https://www.elastic.co/guide/en/elasticsearch/reference/master/heap-size.html
+  elasticsearch['jvm_options'] = {
+    :Xms => '2g',
+    :Xmx => '2g',
+    :Xss => '1m'
+  }
+end

--- a/cookbooks/ey-elasticsearch/definitions/plugin.rb
+++ b/cookbooks/ey-elasticsearch/definitions/plugin.rb
@@ -1,0 +1,23 @@
+define :es_plugin, :name => nil do
+  name = params['name']
+
+  case params['action'].to_sym
+  when :install
+    Chef::Log.info "attempting to install ElasticSearch plugin #{name}"
+
+    execute "plugin install #{name}" do
+      cwd "/opt/elasticsearch"
+      command "/opt/elasticsearch/bin/plugin -install #{name}"
+      not_if { File.directory?("/opt/elasticsearch/plugins/#{name}") }
+    end
+
+  when :remove
+    Chef::Log.info "attempting to remove ElasticSearch plugin #{name}"
+
+    execute "plugin remove #{name}" do
+      cwd "/opt/elasticsearch"
+      command "/opt/elasticsearch/bin/plugin -remove #{name}"
+      not_if { File.directory?("/opt/elasticsearch/plugins/#{name}") }
+    end
+  end
+end

--- a/cookbooks/ey-elasticsearch/definitions/plugin.rb
+++ b/cookbooks/ey-elasticsearch/definitions/plugin.rb
@@ -1,7 +1,7 @@
-define :es_plugin, :name => nil do
-  name = params['name']
+define :es_plugin, name: nil do
+  name = params["name"]
 
-  case params['action'].to_sym
+  case params["action"].to_sym
   when :install
     Chef::Log.info "attempting to install ElasticSearch plugin #{name}"
 

--- a/cookbooks/ey-elasticsearch/files/default/elasticsearch-service.override.conf
+++ b/cookbooks/ey-elasticsearch/files/default/elasticsearch-service.override.conf
@@ -1,0 +1,2 @@
+[Service]
+Restart=on-failure

--- a/cookbooks/ey-elasticsearch/files/default/elasticsearch.logrotate
+++ b/cookbooks/ey-elasticsearch/files/default/elasticsearch.logrotate
@@ -1,0 +1,12 @@
+/var/log/elasticsearch/*.log {
+    rotate 30
+    size 100M
+    compress
+    missingok
+    notifempty
+    sharedscripts
+    extension gz
+    postrotate
+      [ ! -f /var/run/elasticsearch/elasticsearch.pid ] || kill -USR1 `cat /var/run/elasticsearch/elasticsearch.pid`
+    endscript
+}

--- a/cookbooks/ey-elasticsearch/metadata.rb
+++ b/cookbooks/ey-elasticsearch/metadata.rb
@@ -1,0 +1,8 @@
+name 'ey-elasticsearch'
+description 'Configuration & deployment of Elasticsearch on Engine Yard'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+maintainer 'Engine Yard'
+maintainer_email 'support@engineyard.com'
+version '6.0.0'
+issues_url 'https://github.com/engineyard/ey-cookbooks-stable-v7/issues'
+source_url 'https://github.com/engineyard/ey-cookbooks-stable-v7'

--- a/cookbooks/ey-elasticsearch/metadata.rb
+++ b/cookbooks/ey-elasticsearch/metadata.rb
@@ -1,8 +1,8 @@
-name 'ey-elasticsearch'
-description 'Configuration & deployment of Elasticsearch on Engine Yard'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-maintainer 'Engine Yard'
-maintainer_email 'support@engineyard.com'
-version '6.0.0'
-issues_url 'https://github.com/engineyard/ey-cookbooks-stable-v7/issues'
-source_url 'https://github.com/engineyard/ey-cookbooks-stable-v7'
+name "ey-elasticsearch"
+description "Configuration & deployment of Elasticsearch on Engine Yard"
+long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
+maintainer "Engine Yard"
+maintainer_email "support@engineyard.com"
+version "6.0.0"
+issues_url "https://github.com/engineyard/ey-cookbooks-stable-v7/issues"
+source_url "https://github.com/engineyard/ey-cookbooks-stable-v7"

--- a/cookbooks/ey-elasticsearch/metadata.rb
+++ b/cookbooks/ey-elasticsearch/metadata.rb
@@ -1,6 +1,5 @@
 name "ey-elasticsearch"
 description "Configuration & deployment of Elasticsearch on Engine Yard"
-long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 maintainer "Engine Yard"
 maintainer_email "support@engineyard.com"
 version "6.0.0"

--- a/cookbooks/ey-elasticsearch/recipes/apt.rb
+++ b/cookbooks/ey-elasticsearch/recipes/apt.rb
@@ -1,0 +1,31 @@
+ES = node['elasticsearch']
+es_version_series = "#{ES['version'][0]}.x"
+
+if ES['is_elasticsearch_instance']
+  Chef::Log.info "Setting up the Elasticsearch #{es_version_series} APT repository"
+
+  execute "Add GPG-KEY-elasticsearch" do
+    command "wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo gpg --dearmor -o /usr/share/keyrings/elasticsearch-keyring.gpg --yes"
+    action :run
+  end 
+
+#  execute "apt-get install apt-transport-https" do
+#    command "apt-get install apt-transport-https"
+#    action :run
+#  end
+
+apt_package 'apt-transport-https' do
+  action :install
+end
+
+execute "apt-get update for elasticsearch-#{es_version_series}" do
+  command "apt-get update"
+  action :nothing
+end
+
+  execute "Add repository definition for elasticsearch-#{es_version_series}" do
+   command "echo 'deb [signed-by=/usr/share/keyrings/elasticsearch-keyring.gpg] https://artifacts.elastic.co/packages/#{es_version_series}/apt stable main' | sudo tee /etc/apt/sources.list.d/elastic-#{es_version_series}.list "
+   action :run 
+   notifies :run, "execute[apt-get update for elasticsearch-#{es_version_series}]", :immediately
+  end
+end

--- a/cookbooks/ey-elasticsearch/recipes/apt.rb
+++ b/cookbooks/ey-elasticsearch/recipes/apt.rb
@@ -1,31 +1,31 @@
-ES = node['elasticsearch']
+ES = node["elasticsearch"]
 es_version_series = "#{ES['version'][0]}.x"
 
-if ES['is_elasticsearch_instance']
+if ES["is_elasticsearch_instance"]
   Chef::Log.info "Setting up the Elasticsearch #{es_version_series} APT repository"
 
   execute "Add GPG-KEY-elasticsearch" do
     command "wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo gpg --dearmor -o /usr/share/keyrings/elasticsearch-keyring.gpg --yes"
     action :run
-  end 
+  end
 
-#  execute "apt-get install apt-transport-https" do
-#    command "apt-get install apt-transport-https"
-#    action :run
-#  end
+  #  execute "apt-get install apt-transport-https" do
+  #    command "apt-get install apt-transport-https"
+  #    action :run
+  #  end
 
-apt_package 'apt-transport-https' do
-  action :install
-end
+  apt_package "apt-transport-https" do
+    action :install
+  end
 
-execute "apt-get update for elasticsearch-#{es_version_series}" do
-  command "apt-get update"
-  action :nothing
-end
+  execute "apt-get update for elasticsearch-#{es_version_series}" do
+    command "apt-get update"
+    action :nothing
+  end
 
   execute "Add repository definition for elasticsearch-#{es_version_series}" do
-   command "echo 'deb [signed-by=/usr/share/keyrings/elasticsearch-keyring.gpg] https://artifacts.elastic.co/packages/#{es_version_series}/apt stable main' | sudo tee /etc/apt/sources.list.d/elastic-#{es_version_series}.list "
-   action :run 
-   notifies :run, "execute[apt-get update for elasticsearch-#{es_version_series}]", :immediately
+    command "echo 'deb [signed-by=/usr/share/keyrings/elasticsearch-keyring.gpg] https://artifacts.elastic.co/packages/#{es_version_series}/apt stable main' | sudo tee /etc/apt/sources.list.d/elastic-#{es_version_series}.list "
+    action :run
+    notifies :run, "execute[apt-get update for elasticsearch-#{es_version_series}]", :immediately
   end
 end

--- a/cookbooks/ey-elasticsearch/recipes/configure_cluster.rb
+++ b/cookbooks/ey-elasticsearch/recipes/configure_cluster.rb
@@ -1,14 +1,14 @@
-ES = node['elasticsearch']
+ES = node["elasticsearch"]
 
-if node['dna']['utility_instances'].empty?
+if node["dna"]["utility_instances"].empty?
   Chef::Log.info "No utility instances found"
 else
   elasticsearch_instances = []
   elasticsearch_expected = 0
-  node['dna']['utility_instances'].each do |elasticsearch|
-    if elasticsearch['name'].include?("elasticsearch")
-      unless node['dna']['fqdn'] == elasticsearch['hostname']
-        elasticsearch_expected = elasticsearch_expected + 1
+  node["dna"]["utility_instances"].each do |elasticsearch|
+    if elasticsearch["name"].include?("elasticsearch")
+      unless node["dna"]["fqdn"] == elasticsearch["hostname"]
+        elasticsearch_expected += 1
         elasticsearch_instances << "#{elasticsearch['hostname']}:9300"
       end
     end
@@ -19,12 +19,12 @@ else
     owner "elasticsearch"
     group "elasticsearch"
     variables(
-      :elasticsearch_instances => elasticsearch_instances.join('", "'),
-      :elasticsearch_defaultreplicas => ES['defaultreplicas'],
-      :elasticsearch_expected => elasticsearch_expected,
-      :elasticsearch_defaultshards => ES['defaultshards'],
-      :elasticsearch_clustername => ES['clustername'],
-      :elasticsearch_host => node['fqdn']
+      elasticsearch_instances: elasticsearch_instances.join('", "'),
+      elasticsearch_defaultreplicas: ES["defaultreplicas"],
+      elasticsearch_expected: elasticsearch_expected,
+      elasticsearch_defaultshards: ES["defaultshards"],
+      elasticsearch_clustername: ES["clustername"],
+      elasticsearch_host: node["fqdn"]
     )
     mode 0600
     backup 0

--- a/cookbooks/ey-elasticsearch/recipes/configure_cluster.rb
+++ b/cookbooks/ey-elasticsearch/recipes/configure_cluster.rb
@@ -26,7 +26,7 @@ else
       elasticsearch_clustername: ES["clustername"],
       elasticsearch_host: node["fqdn"]
     )
-    mode 0600
+    mode "600"
     backup 0
   end
 end

--- a/cookbooks/ey-elasticsearch/recipes/configure_cluster.rb
+++ b/cookbooks/ey-elasticsearch/recipes/configure_cluster.rb
@@ -1,0 +1,32 @@
+ES = node['elasticsearch']
+
+if node['dna']['utility_instances'].empty?
+  Chef::Log.info "No utility instances found"
+else
+  elasticsearch_instances = []
+  elasticsearch_expected = 0
+  node['dna']['utility_instances'].each do |elasticsearch|
+    if elasticsearch['name'].include?("elasticsearch")
+      unless node['dna']['fqdn'] == elasticsearch['hostname']
+        elasticsearch_expected = elasticsearch_expected + 1
+        elasticsearch_instances << "#{elasticsearch['hostname']}:9300"
+      end
+    end
+  end
+
+  template "/etc/elasticsearch/elasticsearch.yml" do
+    source "elasticsearch.yml.erb"
+    owner "elasticsearch"
+    group "elasticsearch"
+    variables(
+      :elasticsearch_instances => elasticsearch_instances.join('", "'),
+      :elasticsearch_defaultreplicas => ES['defaultreplicas'],
+      :elasticsearch_expected => elasticsearch_expected,
+      :elasticsearch_defaultshards => ES['defaultshards'],
+      :elasticsearch_clustername => ES['clustername'],
+      :elasticsearch_host => node['fqdn']
+    )
+    mode 0600
+    backup 0
+  end
+end

--- a/cookbooks/ey-elasticsearch/recipes/default.rb
+++ b/cookbooks/ey-elasticsearch/recipes/default.rb
@@ -1,0 +1,14 @@
+#
+# Cookbook Name:: elasticsearch
+# Recipe:: default
+#
+# Credit goes to GoTime for their original recipe ( http://cookbooks.opscode.com/cookbooks/elasticsearch )
+
+ES = node['elasticsearch']
+
+include_recipe 'ey-elasticsearch::apt'
+include_recipe 'ey-elasticsearch::install'
+if ES['is_elasticsearch_instance']
+  include_recipe 'ey-elasticsearch::configure_cluster'
+  include_recipe 'ey-elasticsearch::start'
+end

--- a/cookbooks/ey-elasticsearch/recipes/default.rb
+++ b/cookbooks/ey-elasticsearch/recipes/default.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: elasticsearch
+# Cookbook:: elasticsearch
 # Recipe:: default
 #
 # Credit goes to GoTime for their original recipe ( http://cookbooks.opscode.com/cookbooks/elasticsearch )

--- a/cookbooks/ey-elasticsearch/recipes/default.rb
+++ b/cookbooks/ey-elasticsearch/recipes/default.rb
@@ -4,11 +4,11 @@
 #
 # Credit goes to GoTime for their original recipe ( http://cookbooks.opscode.com/cookbooks/elasticsearch )
 
-ES = node['elasticsearch']
+ES = node["elasticsearch"]
 
-include_recipe 'ey-elasticsearch::apt'
-include_recipe 'ey-elasticsearch::install'
-if ES['is_elasticsearch_instance']
-  include_recipe 'ey-elasticsearch::configure_cluster'
-  include_recipe 'ey-elasticsearch::start'
+include_recipe "ey-elasticsearch::apt"
+include_recipe "ey-elasticsearch::install"
+if ES["is_elasticsearch_instance"]
+  include_recipe "ey-elasticsearch::configure_cluster"
+  include_recipe "ey-elasticsearch::start"
 end

--- a/cookbooks/ey-elasticsearch/recipes/install.rb
+++ b/cookbooks/ey-elasticsearch/recipes/install.rb
@@ -1,0 +1,102 @@
+ES = node['elasticsearch']
+es_version_series = "#{ES['version'][0]}.x"
+
+if ES['is_elasticsearch_instance']
+  package 'default-jdk'
+
+  package 'elasticsearch' do
+    version ES['version']
+  end
+
+  directory ES['home'] do
+    owner "elasticsearch"
+    group "elasticsearch"
+    mode 0755
+  end
+
+  directory "/data/elasticsearch-#{ES['version']}/data" do
+    owner "elasticsearch"
+    group "elasticsearch"
+    mode 0755
+    action :create
+    recursive true
+  end
+
+  if File.new("/proc/mounts").readlines.join.match(/\/data\/elasticsearch-#{ES['version']}\/data/)
+    Chef::Log.info("Elastic search bind already complete")
+  else
+    mount "/data/elasticsearch-#{ES['version']}/data" do
+      device ES['home']
+      fstype "none"
+      options "bind,rw"
+      action :mount
+    end
+  end
+
+  # Create the jvm.options file
+  template "/etc/elasticsearch/jvm.options" do
+    cookbook "custom-elasticsearch"
+    source "jvm.options.#{es_version_series}.erb"
+    mode "0644"
+    backup 0
+    variables(
+      :Xms => ES['jvm_options']['Xms'],
+      :Xmx => ES['jvm_options']['Xmx'],
+      :Xss => ES['jvm_options']['Xss']
+    )
+  end
+
+  # Add log rotation for the elasticsearch logs
+  cookbook_file "/etc/logrotate.d/elasticsearch" do
+    source "elasticsearch.logrotate"
+    owner "root"
+    group "root"
+    mode "0644"
+    backup 0
+  end
+
+  # Add elasticsearch systemd override.conf
+  directory "/etc/systemd/system/elasticsearch.service.d" do
+    owner "root"
+    group "root"
+    mode 0755
+    recursive true
+    action :create
+  end
+
+  cookbook_file "/etc/systemd/system/elasticsearch.service.d/override.conf" do
+    source "elasticsearch-service.override.conf"
+    owner "root"
+    group "root"
+    mode "0644"
+    backup 0
+    notifies :run, "execute[reload-systemd]", :immediately
+  end
+end
+
+owner_name = node['dna']['users'].first['username']
+# This portion of the recipe should run on all instances in your environment.
+# We are going to drop elasticsearch.yml for you so you can parse it and provide the instances to your application.
+if ['solo','app_master','app','util'].include?(node['dna']['instance_role'])
+  elasticsearch_hosts = []
+  node['dna']['utility_instances'].each do |instance|
+    if instance['name'].include?(ES['instance_name'])
+      elasticsearch_hosts << "#{instance['hostname']}:9200"
+    end
+  end
+
+  node['dna']['applications'].each do |app_name, data|
+    template "/data/#{app_name}/shared/config/elasticsearch.yml" do
+      owner owner_name
+      group owner_name
+      mode 0660
+      source "es.yml.erb"
+      backup 0
+      variables(:yaml_file => {
+        node['dna']['environment']['framework_env'] => {
+          "hosts" => elasticsearch_hosts
+        }
+      })
+    end
+  end
+end

--- a/cookbooks/ey-elasticsearch/recipes/install.rb
+++ b/cookbooks/ey-elasticsearch/recipes/install.rb
@@ -11,13 +11,13 @@ if ES["is_elasticsearch_instance"]
   directory ES["home"] do
     owner "elasticsearch"
     group "elasticsearch"
-    mode 0755
+    mode "755"
   end
 
   directory "/data/elasticsearch-#{ES['version']}/data" do
     owner "elasticsearch"
     group "elasticsearch"
-    mode 0755
+    mode "755"
     action :create
     recursive true
   end
@@ -59,7 +59,7 @@ if ES["is_elasticsearch_instance"]
   directory "/etc/systemd/system/elasticsearch.service.d" do
     owner "root"
     group "root"
-    mode 0755
+    mode "755"
     recursive true
     action :create
   end
@@ -89,7 +89,7 @@ if ["solo", "app_master", "app", "util"].include?(node["dna"]["instance_role"])
     template "/data/#{app_name}/shared/config/elasticsearch.yml" do
       owner owner_name
       group owner_name
-      mode 0660
+      mode "660"
       source "es.yml.erb"
       backup 0
       variables(yaml_file: {

--- a/cookbooks/ey-elasticsearch/recipes/start.rb
+++ b/cookbooks/ey-elasticsearch/recipes/start.rb
@@ -1,3 +1,3 @@
-service 'elasticsearch' do
+service "elasticsearch" do
   action [:start, :enable]
 end

--- a/cookbooks/ey-elasticsearch/recipes/start.rb
+++ b/cookbooks/ey-elasticsearch/recipes/start.rb
@@ -1,0 +1,3 @@
+service 'elasticsearch' do
+  action [:start, :enable]
+end

--- a/cookbooks/ey-elasticsearch/templates/default/elasticsearch.yml.erb
+++ b/cookbooks/ey-elasticsearch/templates/default/elasticsearch.yml.erb
@@ -1,0 +1,21 @@
+path:
+  logs: /var/log/elasticsearch
+  data: /data/elasticsearch
+
+
+cluster:
+  name: <%= @elasticsearch_clustername %>
+
+network:
+  bind_host: [127.0.0.1, <%= @elasticsearch_host %>]
+  publish_host: <%= @elasticsearch_host %>
+
+discovery:
+  zen:
+    minimum_master_nodes: 1
+    ping.unicast.hosts: ["<%= @elasticsearch_instances %>"]
+
+gateway:
+  recover_after_nodes: 1
+  recover_after_time: 5m
+  expected_nodes: <%= @elasticsearch_expected %>

--- a/cookbooks/ey-elasticsearch/templates/default/es.yml.erb
+++ b/cookbooks/ey-elasticsearch/templates/default/es.yml.erb
@@ -1,0 +1,2 @@
+<% require 'yaml' -%>
+<%=@yaml_file.to_yaml%>

--- a/custom-cookbooks/elasticsearch/README.md
+++ b/custom-cookbooks/elasticsearch/README.md
@@ -1,0 +1,5 @@
+# Elasticsearch
+
+This example contains a complete cookbooks/ that you can use on the stable-v7 stack.
+
+See https://github.com/engineyard/ey-cookbooks-stable-v7/tree/next-release/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch for complete instructions.

--- a/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/README.md
+++ b/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/README.md
@@ -1,0 +1,213 @@
+# Elasticsearch
+
+This recipe installs Elasticsearch 5.x/6.x/7.x/8.x. Elasticsearch 5.x requires Java 8, Elasticsearch 6.x requires Java 8 Full compatibiliy of elasticserch version with Java is listed https://www.elastic.co/support/matrix#matrix_jvm
+
+## Installation
+
+For simplicity, we recommend that you create the cookbooks directory at the root of your application. If you prefer to keep the infrastructure code separate from application code, you can create a new repository.
+
+Our main recipes have the `elasticsearch` recipe but it is not included by default. To use the `elasticsearch` recipe, you should copy this recipe `custom-elasticsearch`. You should not copy the actual `elasticsearch ` recipe. That is managed by Engine Yard.
+
+1. Edit `cookbooks/ey-custom/recipes/after-main.rb` and add
+
+      ```
+      include_recipe 'custom-elasticsearch'
+      ```
+
+2. Edit `cookbooks/ey-custom/metadata.rb` and add
+
+      ```
+      depends 'custom-elasticsearch'
+      ```
+
+3. Copy `custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch ` to `cookbooks/`
+
+      ```
+      cd ~ # Change this to your preferred directory. Anywhere but inside the application
+
+      git clone https://github.com/engineyard/ey-cookbooks-stable-v7
+      cd ey-cookbooks-stable-v7
+      cp custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch /path/to/app/cookbooks/
+      ```
+
+4. Download the ey-core gem on your local machine and upload the recipes
+
+  ```
+  gem install ey-core
+  ey-core recipes upload --environment=<nameofenvironment> --file=<pathtocookbooksfolder> --apply
+  ```
+
+5. After running chef, ssh to an elasticsearch instance to verify that it's running.
+
+Run:
+
+```
+curl localhost:9200
+```
+
+Results should be simlar to:
+
+```
+{
+  "name" : "ip-10-0-1-185",
+  "cluster_name" : "rubygem",
+  "cluster_uuid" : "_na_",
+  "version" : {
+    "number" : "7.17.2",
+    "build_flavor" : "default",
+    "build_type" : "deb",
+    "build_hash" : "de7261de50d90919ae53b0eff9413fd7e5307301",
+    "build_date" : "2022-03-28T15:12:21.446567561Z",
+    "build_snapshot" : false,
+    "lucene_version" : "8.11.1",
+    "minimum_wire_compatibility_version" : "6.8.0",
+    "minimum_index_compatibility_version" : "6.0.0-beta1"
+  },
+  "tagline" : "You Know, for Search"
+}
+```
+
+## Customizations
+
+All customizations go to `cookbooks/custom-elasticsearch/attributes/default.rb`.
+
+### Choose the instances that run the recipe
+
+By default, the elasticsearch recipe runs on utility instances with a name includes the word `elasticsearch`. You can change this by modifying `attributes/default.rb`.
+
+#### A. Run Elasticsearch on utility instances
+
+* Name the Elasticsearch instances elasticsearch\_0, elasticsearch\_1, etc.
+
+* Uncomment this line:
+
+```
+elasticsearch['is_elasticsearch_instance'] = ( node['dna']['instance_role'] == 'util' && node['dna']['name'].include?('elasticsearch') )
+```
+
+* Make sure this line is commented out:
+
+```
+elasticsearch['is_elasticsearch_instance'] = ( ['solo', 'app_master'].include?(node['dna']['instance_role']) )
+```
+
+* Set `configure_cluster` to true:
+
+```
+elasticsearch['configure_cluster'] = true
+```
+
+#### B. Run Elasticsearch on app_master or on a solo environment
+
+This is not recommended for production environments.
+
+* Uncomment this line:
+
+```
+elasticsearch['is_elasticsearch_instance'] = ( ['solo', 'app_master'].include?(node['dna']['instance_role']) )
+```
+
+* Make sure this line is commented out:
+
+```
+#elasticsearch['is_elasticsearch_instance'] = ( node['dna']['instance_role'] == 'util' && node['dna']['name'].include?('elasticsearch') )
+```
+
+### Specify the Elasticsearch version
+
+Set `elasticsearch['version']` in `attributes/default.rb`, and comment out or delete references to other versions.
+
+```
+  elasticsearch['version'] = '7.17.2'
+```
+
+You need to do the same for `elasticsearch['checksum']` and `elasticsearch['download_url']`.
+
+To calculate the SHA256 checksum, download the zip file and then run:
+
+- `sha256sum <zipfile>` (Linux)
+- `shasum -a 256 <zipfile>` (OSX)
+
+```
+  elasticsearch['checksum'] = '02d9b16334ca97eaaab308bb65743ba18249295d4414f6967c2daf13663cf01d'   # checksum for 5.5.0
+  #elasticsearch['checksum'] = 'bee3ca3d5b2103e09b18e1791d1cc504388b992cc4ebf74869568db13c3d4372'  # checksum for 2.4.4
+```
+
+```
+  # Use this URL for the 5.x.x versions
+  elasticsearch['download_url'] = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-#{elasticsearch['version']}.zip"
+  # Use this URL for the 2.4.x versions
+  #elasticsearch['download_url'] = "https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/zip/elasticsearch/#{elasticsearch['version']}/elasticsearch-#{elasticsearch['version']}.zip"
+```
+
+### Configure JVM Options
+
+_NOTE: As of this writing, this recipe allows you to customize the JVM options only if you're running Elasticsearch 5.x. The chef recipe sets the JVM options through the `jvm.options` file. The earlier 2.x versions do not use this file to configure the JVM options._
+
+You can configure the JVM minimum and maximum heap size, and the stack size setting by editing the jvm_options key in `attributes/default.rb`:
+
+```
+elasticsearch['jvm_options'] = {
+  :Xms => '2g',
+  :Xmx => '2g',
+  :Xss => '1m'
+}
+```
+
+For guidelines on how to calculate the optimal JVM memory settings, see [https://www.elastic.co/guide/en/elasticsearch/reference/master/heap-size.html](https://www.elastic.co/guide/en/elasticsearch/reference/master/heap-size.html).
+
+You can also hard-code other JVM options by editing `custom-elasticsearch/templates/default/jvm.options.erb`.
+
+After updating the JVM options, you need to restart Elasticsearch by running `sudo systemctl restart elasticsearch.service` on all Elasticsearch instances. The recipe does not automatically restart Elasticsearch as that can cause downtime.
+
+## Upgrading
+
+If you have a small index and can easily rebuild it, the simplest way to upgrade from a previous version is to completely delete `/data/elasticsearch` and then re-run the recipe with the newer version. To do an in-place upgrade while keeping the index, please consult the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-upgrade.html).
+
+If you’re upgrading from 2.x to 5.x, the 5.x versions require higher limits in `/etc/security/limits.conf`. The latest version of the recipe sets up the higher limits on `/etc/security/limits.conf`, but an instance reboot is needed for the change to take effect. Terminating the old ES 2.x instance and booting a new one may be the simpler path. 
+
+Or in oder to upgrade from 7.x you can refer the upgrade instructions https://www.elastic.co/guide/en/elasticsearch/reference/7.17/setup-upgrade.html and for upgrading to 8.x https://www.elastic.co/guide/en/elastic-stack/8.3/upgrading-elastic-stack.html the process very on the basis of your current version and breaking chages between the versions.  
+
+## Dependencies
+
+  * Your application should use gems(s) such as [tire][4],[rubberband][3],[elastic_searchable][5].
+
+Plugins
+--------
+
+Rudamentary plugin support is there in a definition.  You will need to update the template for configuration options for said plugin; if you wish to improve this functionality please submit a pull request.
+
+custom-cookbooks:
+
+``es_plugin "cloud-aws" do``
+``action :install``
+``end``
+
+``es_plugin "transport-memcached" do``
+``action :remove``
+``end``
+
+
+Caveats
+--------
+
+plugin support is still not complete/automated. CouchDB and Memcached plugins may be worth investigating, pull requests to improve this.
+
+Backups
+--------
+
+Non-automated, regular snapshot should work. If you have a large cluster this may complicate things, please consult the [elasticsearch][2] documentation regarding that.
+
+
+Warranty
+--------
+
+This cookbook is provided as is, there is no offer of support for this
+recipe by Engine Yard in any capacity.  If you find bugs, please open an
+issue and submit a pull request.
+
+[1]: http://lucene.apache.org/
+[2]: http://www.elasticsearch.org/
+[3]: https://github.com/grantr/rubberband
+[4]: https://github.com/karmi/tire
+[5]: https://github.com/wireframe/elastic_searchable/

--- a/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/attributes/default.rb
+++ b/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/attributes/default.rb
@@ -14,7 +14,7 @@ default['elasticsearch'].tap do |elasticsearch|
   # Elasticsearch version to install
   # Go to https://www.elastic.co/downloads/past-releases to see the available version
   # elasticsearch['version'] = '5.6.15'
-  elasticsearch['version'] = '6.6.3'
+  elasticsearch['version'] = '6.8.0'
   # elasticsearch['version'] = '7.17.2'
   # elasticsearch['version'] = '8.2.3'
   

--- a/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/attributes/default.rb
+++ b/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/attributes/default.rb
@@ -14,7 +14,7 @@ default['elasticsearch'].tap do |elasticsearch|
   # Elasticsearch version to install
   # Go to https://www.elastic.co/downloads/past-releases to see the available version
   # elasticsearch['version'] = '5.6.15'
-  elasticsearch['version'] = 6.6.3'
+  elasticsearch['version'] = '6.6.3'
   # elasticsearch['version'] = '7.17.2'
   # elasticsearch['version'] = '8.2.3'
   

--- a/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/attributes/default.rb
+++ b/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/attributes/default.rb
@@ -1,0 +1,40 @@
+default['elasticsearch'].tap do |elasticsearch|
+  # Run Elasticsearch on util instances containing elasticsearch in name
+  # This is the default
+  elasticsearch['instance_name'] = 'elasticsearch'
+  elasticsearch['is_elasticsearch_instance'] = (
+    node['dna']['instance_role'] == 'util' &&
+    node['dna']['name'].include?(elasticsearch['instance_name'])
+  )
+
+  # Run Elasticsearch on a solo or app_master instance
+  # Not recommended for production environments
+  #elasticsearch['is_elasticsearch_instance'] = ( ['solo', 'app_master'].include?(node['dna']['instance_role']) )
+
+  # Elasticsearch version to install
+  # Go to https://www.elastic.co/downloads/past-releases to see the available version
+  # elasticsearch['version'] = '5.6.15'
+  elasticsearch['version'] = 6.6.2'
+  # elasticsearch['version'] = '7.17.2'
+  # elasticsearch['version'] = '8.2.3'
+  
+
+  # Elasticsearch cluster name
+  elasticsearch['clustername'] = node['dna']['environment']['name']
+
+  # Where to store the ES index
+  elasticsearch['home'] = '/data/elasticsearch'
+
+  # Elasticsearch configuration parameters
+  elasticsearch['defaultreplicas'] = 1
+  elasticsearch['defaultshards'] = 6
+
+  # JVM Options, will be used to populate /etc/elasticsearch/jvm.options
+  # For guidelines on how to calculate the optimal JVM memory settings,
+  # see https://www.elastic.co/guide/en/elasticsearch/reference/master/heap-size.html
+  elasticsearch['jvm_options'] = {
+    :Xms => '2g',
+    :Xmx => '2g',
+    :Xss => '1m'
+  }
+end

--- a/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/attributes/default.rb
+++ b/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/attributes/default.rb
@@ -14,7 +14,7 @@ default['elasticsearch'].tap do |elasticsearch|
   # Elasticsearch version to install
   # Go to https://www.elastic.co/downloads/past-releases to see the available version
   # elasticsearch['version'] = '5.6.15'
-  elasticsearch['version'] = 6.6.2'
+  elasticsearch['version'] = 6.6.3'
   # elasticsearch['version'] = '7.17.2'
   # elasticsearch['version'] = '8.2.3'
   

--- a/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/metadata.rb
+++ b/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/metadata.rb
@@ -1,0 +1,10 @@
+name 'custom-elasticsearch'
+description 'Configuration & deployment of Elasticsearch on Engine Yard'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+maintainer 'Engine Yard'
+maintainer_email 'support@engineyard.com'
+version '0.0.1'
+issues_url 'https://github.com/engineyard/ey-cookbooks-stable-v7/issues'
+source_url 'https://github.com/engineyard/ey-cookbooks-stable-v7'
+
+depends 'ey-elasticsearch'

--- a/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/recipes/default.rb
+++ b/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/recipes/default.rb
@@ -1,0 +1,1 @@
+include_recipe 'ey-elasticsearch'

--- a/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/templates/default/jvm.options.5.x.erb
+++ b/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/templates/default/jvm.options.5.x.erb
@@ -1,0 +1,111 @@
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+-Xms<%= @Xms %>
+-Xmx<%= @Xmx %>
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+-XX:+UseConcMarkSweepGC
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+
+## optimizations
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# force the server VM (remove on 32-bit client JVMs)
+-server
+
+# explicitly set the stack size (reduce to 320k on 32-bit client JVMs)
+-Xss<%= @Xss %>
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# use old-style file permissions on JDK9
+-Djdk.io.permissionsUseCanonicalPath=true
+
+# flags to configure Netty
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+-Dlog4j.skipJansi=true
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps
+# ensure the directory exists and has sufficient space
+#-XX:HeapDumpPath=${heap.dump.path}
+
+## GC logging
+
+#-XX:+PrintGCDetails
+#-XX:+PrintGCTimeStamps
+#-XX:+PrintGCDateStamps
+#-XX:+PrintClassHistogram
+#-XX:+PrintTenuringDistribution
+#-XX:+PrintGCApplicationStoppedTime
+
+# log GC status to a file with time stamps
+# ensure the directory exists
+#-Xloggc:${loggc}
+
+# By default, the GC log file will not rotate.
+# By uncommenting the lines below, the GC log file
+# will be rotated every 128MB at most 32 times.
+#-XX:+UseGCLogFileRotation
+#-XX:NumberOfGCLogFiles=32
+#-XX:GCLogFileSize=128M
+
+# Elasticsearch 5.0.0 will throw an exception on unquoted field names in JSON.
+# If documents were already indexed with unquoted fields in a previous version
+# of Elasticsearch, some operations may throw errors.
+#
+# WARNING: This option will be removed in Elasticsearch 6.0.0 and is provided
+# only for migration purposes.
+#-Delasticsearch.json.allow_unquoted_field_names=true

--- a/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/templates/default/jvm.options.6.x.erb
+++ b/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/templates/default/jvm.options.6.x.erb
@@ -1,0 +1,122 @@
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+-Xms<%= @Xms %>
+-Xmx<%= @Xmx %>
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+-XX:+UseConcMarkSweepGC
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+
+## G1GC Configuration
+# NOTE: G1GC is only supported on JDK version 10 or later.
+# To use G1GC uncomment the lines below.
+# 10-:-XX:-UseConcMarkSweepGC
+# 10-:-XX:-UseCMSInitiatingOccupancyOnly
+# 10-:-XX:+UseG1GC
+# 10-:-XX:InitiatingHeapOccupancyPercent=75
+
+## DNS cache policy
+# cache ttl in seconds for positive DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.ttl; set to -1 to cache forever
+-Des.networkaddress.cache.ttl=60
+# cache ttl in seconds for negative DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.negative ttl; set to -1 to cache
+# forever
+-Des.networkaddress.cache.negative.ttl=10
+
+## optimizations
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# explicitly set the stack size
+-Xss<%= @Xss %>
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# turn off a JDK optimization that throws away stack traces for common
+# exceptions because stack traces are important for debugging
+-XX:-OmitStackTraceInFastThrow
+
+# flags to configure Netty
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+
+-Djava.io.tmpdir=${ES_TMPDIR}
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps; ensure the directory exists and
+# has sufficient space
+-XX:HeapDumpPath=/var/lib/elasticsearch
+
+# specify an alternative path for JVM fatal error logs
+-XX:ErrorFile=/var/log/elasticsearch/hs_err_pid%p.log
+
+## JDK 8 GC logging
+
+8:-XX:+PrintGCDetails
+8:-XX:+PrintGCDateStamps
+8:-XX:+PrintTenuringDistribution
+8:-XX:+PrintGCApplicationStoppedTime
+8:-Xloggc:/var/log/elasticsearch/gc.log
+8:-XX:+UseGCLogFileRotation
+8:-XX:NumberOfGCLogFiles=32
+8:-XX:GCLogFileSize=64m
+
+# JDK 9+ GC logging
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=/var/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+# due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
+# time/date parsing will break in an incompatible way for some date patterns and locals
+9-:-Djava.locale.providers=COMPAT
+
+# temporary workaround for C2 bug with JDK 10 on hardware with AVX-512
+10-:-XX:UseAVX=2

--- a/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/templates/default/jvm.options.7.x.erb
+++ b/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/templates/default/jvm.options.7.x.erb
@@ -18,10 +18,10 @@
 
 # Xms represents the initial size of total heap space
 # Xmx represents the maximum size of total heap space
--Xmx2g
--Xms2g
-8:-Xmx2g
-8-9:-Xmx2g
+-Xmx<%= @Xmx %>
+-Xms<%= @Xms %>
+8:-Xmx<%= @Xmx %>
+8-9:-Xmx<%= @Xmx %>
 
 ################################################################
 ## Expert settings

--- a/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/templates/default/jvm.options.7.x.erb
+++ b/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/templates/default/jvm.options.7.x.erb
@@ -1,0 +1,124 @@
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+-Xmx2g
+-Xms2g
+8:-Xmx2g
+8-9:-Xmx2g
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
+
+## G1GC Configuration
+# NOTE: G1GC is only supported on JDK version 10 or later.
+# To use G1GC uncomment the lines below.
+# 10-:-XX:-UseConcMarkSweepGC
+# 10-:-XX:-UseCMSInitiatingOccupancyOnly
+14-:-XX:+UseG1GC
+14-:-XX:G1ReservePercent=25
+14-:-XX:InitiatingHeapOccupancyPercent=30
+
+## DNS cache policy
+# cache ttl in seconds for positive DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.ttl; set to -1 to cache forever
+-Des.networkaddress.cache.ttl=60
+# cache ttl in seconds for negative DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.negative ttl; set to -1 to cache
+# forever
+-Des.networkaddress.cache.negative.ttl=10
+
+## optimizations
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# explicitly set the stack size
+-Xss1m
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# turn off a JDK optimization that throws away stack traces for common
+# exceptions because stack traces are important for debugging
+-XX:-OmitStackTraceInFastThrow
+
+# flags to configure Netty
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+
+## JVM temporary directory
+-Djava.io.tmpdir=${ES_TMPDIR}
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps; ensure the directory exists and
+# has sufficient space
+-XX:HeapDumpPath=/var/lib/elasticsearch
+
+# specify an alternative path for JVM fatal error logs
+-XX:ErrorFile=/var/log/elasticsearch/hs_err_pid%p.log
+
+## JDK 8 GC logging
+8:-XX:+PrintGCDetails
+8:-XX:+PrintGCDateStamps
+8:-XX:+PrintTenuringDistribution
+8:-XX:+PrintGCApplicationStoppedTime
+8:-Xloggc:/var/log/elasticsearch/gc.log
+8:-XX:+UseGCLogFileRotation
+8:-XX:NumberOfGCLogFiles=32
+8:-XX:GCLogFileSize=64m
+
+# JDK 9+ GC logging
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=/var/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+# due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
+# time/date parsing will break in an incompatible way for some date patterns and locals
+9-:-Djava.locale.providers=COMPAT
+
+# temporary workaround for C2 bug with JDK 10 on hardware with AVX-512
+10-:-XX:UseAVX=2

--- a/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/templates/default/jvm.options.8.x.erb
+++ b/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/templates/default/jvm.options.8.x.erb
@@ -18,10 +18,10 @@
 
 # Xms represents the initial size of total heap space
 # Xmx represents the maximum size of total heap space
--Xmx2g
--Xms2g
-8:-Xmx2g
-8-9:-Xmx2g
+-Xmx<%= @Xmx %>
+-Xms<%= @Xms %>
+8:-Xmx<%= @Xmx %>
+8-9:-Xmx<%= @Xmx %>
 
 ################################################################
 ## Expert settings

--- a/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/templates/default/jvm.options.8.x.erb
+++ b/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/templates/default/jvm.options.8.x.erb
@@ -1,0 +1,124 @@
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+-Xmx2g
+-Xms2g
+8:-Xmx2g
+8-9:-Xmx2g
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
+
+## G1GC Configuration
+# NOTE: G1GC is only supported on JDK version 10 or later.
+# To use G1GC uncomment the lines below.
+# 10-:-XX:-UseConcMarkSweepGC
+# 10-:-XX:-UseCMSInitiatingOccupancyOnly
+14-:-XX:+UseG1GC
+14-:-XX:G1ReservePercent=25
+14-:-XX:InitiatingHeapOccupancyPercent=30
+
+## DNS cache policy
+# cache ttl in seconds for positive DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.ttl; set to -1 to cache forever
+-Des.networkaddress.cache.ttl=60
+# cache ttl in seconds for negative DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.negative ttl; set to -1 to cache
+# forever
+-Des.networkaddress.cache.negative.ttl=10
+
+## optimizations
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# explicitly set the stack size
+-Xss1m
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# turn off a JDK optimization that throws away stack traces for common
+# exceptions because stack traces are important for debugging
+-XX:-OmitStackTraceInFastThrow
+
+# flags to configure Netty
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+
+## JVM temporary directory
+-Djava.io.tmpdir=${ES_TMPDIR}
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps; ensure the directory exists and
+# has sufficient space
+-XX:HeapDumpPath=/var/lib/elasticsearch
+
+# specify an alternative path for JVM fatal error logs
+-XX:ErrorFile=/var/log/elasticsearch/hs_err_pid%p.log
+
+## JDK 8 GC logging
+8:-XX:+PrintGCDetails
+8:-XX:+PrintGCDateStamps
+8:-XX:+PrintTenuringDistribution
+8:-XX:+PrintGCApplicationStoppedTime
+8:-Xloggc:/var/log/elasticsearch/gc.log
+8:-XX:+UseGCLogFileRotation
+8:-XX:NumberOfGCLogFiles=32
+8:-XX:GCLogFileSize=64m
+
+# JDK 9+ GC logging
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=/var/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+# due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
+# time/date parsing will break in an incompatible way for some date patterns and locals
+9-:-Djava.locale.providers=COMPAT
+
+# temporary workaround for C2 bug with JDK 10 on hardware with AVX-512
+10-:-XX:UseAVX=2

--- a/custom-cookbooks/elasticsearch/cookbooks/ey-custom/metadata.rb
+++ b/custom-cookbooks/elasticsearch/cookbooks/ey-custom/metadata.rb
@@ -1,0 +1,3 @@
+name 'ey-custom'
+
+depends 'custom-elasticsearch'

--- a/custom-cookbooks/elasticsearch/cookbooks/ey-custom/recipes/after-main.rb
+++ b/custom-cookbooks/elasticsearch/cookbooks/ey-custom/recipes/after-main.rb
@@ -1,0 +1,1 @@
+include_recipe 'custom-elasticsearch'


### PR DESCRIPTION
**Description of your patch**
Install and configure Elasticsearch by migrating recipe from v6 to v7

**Recommended Release Notes**
Added support for Elasticsearch installation 

**Estimated risk**
Medium

**Components involved**
ey-elasticsearch

**Dependencies**
none

**Description of testing done**

* Create a new environment with v7 as stack
* Uploaded custom-elasticsearch recipe as per process defined on https://github.com/engineyard/ey-cookbooks-stable-v7/tree/fbz10398_migrate_elasticsearch_recipe/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch#elasticsearch 
* Added utility instance named `elasticsearch`.
* SSH into instance check for elasticsearch service running using `systemctl status elasticsearch.service` version installed  and verify version using `curl localhost:9200`. 

**QA Instructions**
* Create a new environment with v7 as stack
* upload `custom-elasticsearch` recipe as per process defined on https://github.com/engineyard/ey-cookbooks-stable-v7/tree/fbz10398_migrate_elasticsearch_recipe/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch#elasticsearch 
* Add utility instance named `elasticsearch` and allow it to boot.
* SSH into instance check for elasticsearch service running using `systemctl status elasticsearch.service` version installed  and verify version using `curl localhost:9200`. 
