### PR TITLE
[FBZ-10458] Removed v6 references from v7 recipes docs

### DIFF
--- a/cookbooks/ey-delayed-job4/README.md
+++ b/cookbooks/ey-delayed-job4/README.md
@@ -1,6 +1,6 @@
 # Delayed Job
 
-This recipe is used to run Delayed Job on the stable-v6 stack.
+This recipe is used to run Delayed Job on the stable-v7 stack.
 
 The delayed_job4 recipe is managed by Engine Yard. You should not copy this recipe to your repository but instead copy custom-delayed_job4. Please check the [custom-delayed_job4 readme](../../custom-cookbooks/delayed_job4/cookbooks/custom-delayed_job4) for the complete instructions.
 

--- a/custom-cookbooks/delayed_job4/README.md
+++ b/custom-cookbooks/delayed_job4/README.md
@@ -1,5 +1,5 @@
 # Delayed Job
 
-This example contains a complete cookbooks/ that you can use on the stable-v6 stack.
+This example contains a complete cookbooks/ that you can use on the stable-v7 stack.
 
-See https://github.com/engineyard/ey-cookbooks-stable-v6/tree/next-release/custom-cookbooks/delayed_job4/cookbooks/custom-delayed_job4 for complete instructions.
+See https://github.com/engineyard/ey-cookbooks-stable-v7/tree/next-release/custom-cookbooks/delayed_job4/cookbooks/custom-delayed_job4 for complete instructions.

--- a/custom-cookbooks/delayed_job4/cookbooks/custom-delayed_job4/README.md
+++ b/custom-cookbooks/delayed_job4/cookbooks/custom-delayed_job4/README.md
@@ -27,8 +27,8 @@ Our main recipes have the `delayed_job4` recipe but it is not included by defaul
       ```
       cd ~ # Change this to your preferred directory. Anywhere but inside the application
 
-      git clone https://github.com/engineyard/ey-cookbooks-stable-v6
-      cd ey-cookbooks-stable-v6
+      git clone https://github.com/engineyard/ey-cookbooks-stable-v7
+      cd ey-cookbooks-stable-v7
       cp custom-cookbooks/delayed_job4/cookbooks/custom-delayed_job4 /path/to/app/cookbooks/
       ```
 

--- a/custom-cookbooks/resque/cookbooks/custom-resque/README.md
+++ b/custom-cookbooks/resque/cookbooks/custom-resque/README.md
@@ -43,7 +43,7 @@ If you do not have `cookbooks/ey-custom` on your app repository, you can copy `c
 
 ## Dependencies
 
-`resque` depends on Redis. We recommend using the [Redis recipe](https://github.com/engineyard/ey-cookbooks-stable-v6/tree/master/cookbooks/redis) to setup Redis on the environment.
+`resque` depends on Redis. We recommend using the [Redis recipe](https://github.com/engineyard/ey-cookbooks-stable-v7/tree/master/cookbooks/redis) to setup Redis on the environment.
 
 ## Customizations
 

--- a/custom-cookbooks/resque_scheduler/README.md
+++ b/custom-cookbooks/resque_scheduler/README.md
@@ -1,6 +1,6 @@
 # Resque Scheduler
 
-This example contains a complete cookbooks/ that you can use on the stable-v6 stack.
+This example contains a complete cookbooks/ that you can use on the stable-v7 stack.
 
-See https://github.com/engineyard/ey-cookbooks-stable-v6/tree/next-release/custom-cookbooks/resque_scheduler/cookbooks/custom-resque_scheduler for complete instructions.
+See https://github.com/engineyard/ey-cookbooks-stable-v7/tree/next-release/custom-cookbooks/resque_scheduler/cookbooks/custom-resque_scheduler for complete instructions.
 


### PR DESCRIPTION
**Description of your patch**
Updated all v6 references in cookbook to v7

**Recommended Release Notes**
Updated Stack-v7 references

**Estimated risk**
Low

**Components involved**

- ey-delayed-job4
- custom-resque
- resque_scheduler

**Dependencies**
none

**Description of testing done**

None

QA Instructions

None