### PR TITLE
[FBZ-10457] Updated MySQL recipe for File. usage as ::File.

### DIFF
--- a/cookbooks/ey-mysql/files/default/mysql_start
+++ b/cookbooks/ey-mysql/files/default/mysql_start
@@ -66,8 +66,8 @@ class MysqlStart
           log_mysql_event("MySQL did not start, zapping")
           begin
             pidfile = '/var/run/mysqld/mysqld.pid'
-            if File.exists?(pidfile)
-              File.open('/var/run/mysqld/mysqld.pid', 'r') do |f|
+            if ::File.exists?(pidfile)
+              ::File.open('/var/run/mysqld/mysqld.pid', 'r') do |f|
                 pid = f.read.to_i
                 Process.kill("TERM", pid)
   
@@ -86,7 +86,7 @@ class MysqlStart
               end
             end
           rescue Exception => e
-            File.open('/root/chef-mysql.log', 'a') do |f|
+            ::File.open('/root/chef-mysql.log', 'a') do |f|
               f.write("Blew up: \n")
               f.write(e.message)
               f.write("\n")

--- a/cookbooks/ey-mysql/recipes/install.rb
+++ b/cookbooks/ey-mysql/recipes/install.rb
@@ -30,12 +30,12 @@ if node["dna"]["instance_role"][/^(db|solo)/]
   execute "dropping lock version file" do
     command "echo $(mysql --version | grep -E -o '(Distrib|Ver) [0-9]+\.[0-9]+\.[0-9]+' | awk '{print $NF}') > #{lock_version_file}"
     action :run
-    only_if { lock_db_version && !File.exist?(lock_version_file) && db_running }
+    only_if { lock_db_version && !::File.exist?(lock_version_file) && db_running }
   end
 
   execute "remove lock version file" do
     command "rm #{lock_version_file}"
-    only_if { !lock_db_version && File.exist?(lock_version_file) }
+    only_if { !lock_db_version && ::File.exist?(lock_version_file) }
   end
 end
 
@@ -70,7 +70,7 @@ if node["dna"]["instance_role"][/db|solo/]
   end
 end
 
-install_version = if File.exist?(node["lock_version_file"])
+install_version = if ::File.exist?(node["lock_version_file"])
                     `cat #{node["lock_version_file"]}`.strip
                   else
                     node["mysql"]["latest_version"]

--- a/cookbooks/ey-mysql/resources/mysql_slave.rb
+++ b/cookbooks/ey-mysql/resources/mysql_slave.rb
@@ -75,7 +75,7 @@ action :action_mysql_slave do
   ruby_block "read-master-status" do
     block do
       unless volume_from_slave_snapshot
-        file_contents = File.read("/db/mysql/.snapshot_backup_master_status.txt")
+        file_contents = ::File.read("/db/mysql/.snapshot_backup_master_status.txt")
         node.override["master_log_file"] = file_contents.match(/File:(.*)\n/)[1].strip
         node.override["master_log_pos"] = file_contents.match(/Position:(.*)\n/)[1].strip
         Chef::Log.info("using master_log_file: " + node["master_log_file"].inspect)
@@ -86,12 +86,12 @@ action :action_mysql_slave do
 
   file "#{node['mysql']['datadir']}/master.info" do
     action :delete
-    only_if { File.exist?("#{node['mysql']['datadir']}/master.info") && !volume_from_slave_snapshot }
+    only_if { ::File.exist?("#{node['mysql']['datadir']}/master.info") && !volume_from_slave_snapshot }
   end
 
   file "#{node['mysql']['datadir']}/relay-log.info" do
     action :delete
-    only_if { File.exist?("#{node['mysql']['datadir']}/relay-log.info") && !volume_from_slave_snapshot }
+    only_if { ::File.exist?("#{node['mysql']['datadir']}/relay-log.info") && !volume_from_slave_snapshot }
   end
 
   execute "remove relay-log.*" do

--- a/cookbooks/ey-mysql/templates/default/my.conf.erb
+++ b/cookbooks/ey-mysql/templates/default/my.conf.erb
@@ -40,9 +40,9 @@ character-sets-dir=/usr/share/mysql/charsets
 err-log				= <%= @logbase %>mysql.err
 
 [mysqld]
-ssl-ca=<%= File.join(@ssldir, 'root.crt') %>
-ssl-cert=<%= File.join(@ssldir, 'server.crt') %>
-ssl-key=<%= File.join(@ssldir, 'server.key') %>
+ssl-ca=<%= ::File.join(@ssldir, 'root.crt') %>
+ssl-cert=<%= ::File.join(@ssldir, 'server.crt') %>
+ssl-key=<%= ::File.join(@ssldir, 'server.key') %>
 
 open_files_limit = 65535
 

--- a/cookbooks/ey-mysql/templates/default/user_my.cnf.erb
+++ b/cookbooks/ey-mysql/templates/default/user_my.cnf.erb
@@ -3,9 +3,9 @@
 <% if @mysql_version >= @mysql_5_7 %>
 ssl-mode=VERIFY_CA
 <% end %>
-ssl-ca=<%= File.join(@home_dir, '.mysql/root.crt') %>
-ssl-cert=<%= File.join(@home_dir, '.mysql/mysql.crt') %>
-ssl-key=<%= File.join(@home_dir, '.mysql/mysql.key') %>
+ssl-ca=<%= ::File.join(@home_dir, '.mysql/root.crt') %>
+ssl-cert=<%= ::File.join(@home_dir, '.mysql/mysql.crt') %>
+ssl-key=<%= ::File.join(@home_dir, '.mysql/mysql.key') %>
 <% end %>
 user=<%= @username %>
 password=<%= @password %>


### PR DESCRIPTION
Description of your patch
Updated all old style usage of 'File.' to '::File' as per https://docs.chef.io/workstation/cookstyle/chef_correctness_scopedfileexist/

Recommended Release Notes
Fixed MySql recipe for MySQL slave chef failure 

Estimated risk
High

Components involved

ey-mysql

Dependencies
none

Description of testing done

* Boot Environment with Stack-v7 and MySQL as database. 
* Try to boot a slave instance and chef if chef succeed  

QA Instructions

* Boot Environment with Stack-v7 and MySQL as database. 
* Try to boot a slave instance and chef if chef succeed. 