### PR TITLE
[FBZ-10448] - Migrate New Relic Infra Recipe to v7

### DIFF
--- a/cookbooks/ey-newrelic_infra/attributes/default.rb
+++ b/cookbooks/ey-newrelic_infra/attributes/default.rb
@@ -1,0 +1,3 @@
+default["newrelic_infra"]["use_newrelic_addon"] = false
+default["newrelic_infra"]["license_key"] = "INSERT_NEW_RELIC_INFRA_KEY"
+default["newrelic_infra"]["display_name"] = nil

--- a/cookbooks/ey-newrelic_infra/files/default/newrelic-infra.list
+++ b/cookbooks/ey-newrelic_infra/files/default/newrelic-infra.list
@@ -1,0 +1,1 @@
+deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt focal main

--- a/cookbooks/ey-newrelic_infra/files/default/newrelic-infra.list
+++ b/cookbooks/ey-newrelic_infra/files/default/newrelic-infra.list
@@ -1,1 +1,0 @@
-deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt focal main

--- a/cookbooks/ey-newrelic_infra/libraries/newrelic_helpers.rb
+++ b/cookbooks/ey-newrelic_infra/libraries/newrelic_helpers.rb
@@ -1,0 +1,28 @@
+module NewrelicHelpers
+  # check that New Relic addon is enabled
+  def newrelic_enabled?
+    !!newrelic_dna
+  end
+
+  # the New Relic license key
+  def newrelic_license_key
+    newrelic_dna["config"]["vars"]["license_key"] if newrelic_enabled?
+  end
+
+  # New Relic config
+  def newrelic_dna
+    @newrelic_dna ||= begin
+      node.engineyard.environment["apps"].each do |app|
+        app["components"].each do |component|
+          if component["key"].eql?("addons")
+            component["collection"].each do |addon|
+              return addon if addon["name"] == "New Relic"
+            end
+          end
+        end
+      end
+
+      nil
+    end
+  end
+end

--- a/cookbooks/ey-newrelic_infra/metadata.rb
+++ b/cookbooks/ey-newrelic_infra/metadata.rb
@@ -1,0 +1,2 @@
+name "ey-newrelic_infra"
+version "1.0.0"

--- a/cookbooks/ey-newrelic_infra/recipes/default.rb
+++ b/cookbooks/ey-newrelic_infra/recipes/default.rb
@@ -1,0 +1,38 @@
+class Chef::Recipe
+  include NewrelicHelpers
+end
+
+apt_repository "newrelic-infra" do
+  uri "https://download.newrelic.com/infrastructure_agent/linux/apt"
+  distribution "focal"
+  components ["main"]
+end.run_action(:add)
+
+apt_update
+
+license_key = if node["newrelic_infra"]["use_newrelic_addon"]
+                newrelic_license_key
+              else
+                node["newrelic_infra"]["license_key"]
+              end
+
+display_name = node["newrelic_infra"]["display_name"]
+
+template "/etc/newrelic-infra.yml" do
+  source "newrelic-infra.yml.erb"
+  owner "root"
+  group "root"
+  mode "0600"
+  backup false
+  variables({
+    license_key: license_key,
+    display_name: display_name,
+  })
+end
+
+execute "curl -s https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | sudo apt-key add -" do
+end
+
+package "newrelic-infra" do
+  action :install
+end

--- a/cookbooks/ey-newrelic_infra/recipes/default.rb
+++ b/cookbooks/ey-newrelic_infra/recipes/default.rb
@@ -4,11 +4,10 @@ end
 
 apt_repository "newrelic-infra" do
   uri "https://download.newrelic.com/infrastructure_agent/linux/apt"
-  distribution "focal"
+  distribution "#{`lsb_release -cs`.strip}"
   components ["main"]
+  key "https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg"
 end.run_action(:add)
-
-apt_update
 
 license_key = if node["newrelic_infra"]["use_newrelic_addon"]
                 newrelic_license_key
@@ -30,8 +29,7 @@ template "/etc/newrelic-infra.yml" do
   })
 end
 
-execute "curl -s https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | sudo apt-key add -" do
-end
+apt_update
 
 package "newrelic-infra" do
   action :install

--- a/cookbooks/ey-newrelic_infra/templates/default/newrelic-infra.yml.erb
+++ b/cookbooks/ey-newrelic_infra/templates/default/newrelic-infra.yml.erb
@@ -1,0 +1,4 @@
+license_key: <%= @license_key %>
+<% if @display_name %>
+display_name: <%= @display_name %>
+<% end %>

--- a/custom-cookbooks/newrelic_infra/README.md
+++ b/custom-cookbooks/newrelic_infra/README.md
@@ -1,0 +1,5 @@
+# New Relic Infrastructure
+
+This example contains a complete cookbooks/ that you can use on the stable-v7 stack.
+
+See https://github.com/engineyard/ey-cookbooks-stable-v7/tree/next-release/custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra for complete instructions.

--- a/custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra/README.md
+++ b/custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra/README.md
@@ -1,0 +1,83 @@
+# Custom New Relic Infrastructure
+
+The newrelic_infra recipe sets up the New Relic Infrastructure agent. This will install the agent in all instances in the environment.
+
+## Installation
+
+For simplicity, we recommend that you create the cookbooks directory at the root of your application. If you prefer to keep the infrastructure code separate from application code, you can create a new repository.
+
+Our main recipes have the `newrelic_infra` recipe but it is not included by default. To use the `newrelic_infra` recipe, you should copy this recipe `custom-newrelic_infra`. You should not copy the actual `newrelic_infra` recipe. That is managed by Engine Yard.
+
+1. Edit `cookbooks/ey-custom/recipes/after-main.rb` and add
+
+      ```
+      include_recipe 'custom-newrelic_infra'
+      ```
+
+2. Edit `cookbooks/ey-custom/metadata.rb` and add
+
+      ```
+      depends 'custom-newrelic_infra'
+      ```
+
+3. Copy `custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra` to `cookbooks/`
+
+      ```
+      cd ~ # Change this to your preferred directory. Anywhere but inside the application
+
+      git clone https://github.com/engineyard/ey-cookbooks-stable-v7
+      cd ey-cookbooks-stable-v7
+      cp custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra /path/to/app/cookbooks/
+      ```
+
+If you do not have `cookbooks/ey-custom` on your app repository, you can copy `custom-cookbooks/newrelic_infra/cookbooks/ey-custom` to `/path/to/app/cookbooks`.
+
+## Customizations
+
+All customizations go to `cookbooks/custom-newrelic_infra/attributes/default.rb`.
+
+### License Key
+
+Please make sure to specify the license key in `custom-newrelic_infra/attributes/default.rb`:
+
+```ruby
+# Replace value with actual license key
+default['newrelic_infra']['license_key'] = "INSERT_NEW_RELIC_INFRA_KEY"
+```
+
+This will be used in generating /etc/newrelic-infra.yml.
+
+If you are using the New Relic account from the New Relic add-on, you can avoid specifying the license key in the attributes file. Please uncomment the following line in `custom-newrelic_infra/attributes/default.rb` to reuse the license key from the add-on:
+
+```ruby
+# To use the license key from the New Relic addon, please uncomment the line below:
+default['newrelic_infra']['use_newrelic_addon'] = true
+```
+
+### Package Version
+
+The recipe installs the newrelic-infra package from New Relic's APT repository.
+
+### Display Name
+
+New Relic Infrastructure uses the hostname as the unique identifier for each host. If you prefer to override the auto-generated hostname for reporting, you can specify your own `display_name` in `custom-newrelic_infra/attributes/default.rb`:
+
+```ruby
+default['newrelic_infra']['display_name'] = "DISPLAY_NAME"
+```
+
+You can dynamically build the display name by using attributes like:
+
+* `node['dna']['instance_role']` - instance role (e.g. "app_master" or "db_slave" or "util")
+* `node['dna']['name']` - name of the instance (e.g. "redis" utility instance)
+* `node['dna']['environment']['name']` - name of the environment
+
+Please refer to the New Relic Infrastructure configuration documentation:
+
+https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent
+
+## Credits
+
+Thanks to [Aviram Radai][1] for showing their recipe on how they installed the New Relic Infrastructure agent in their environment.
+
+[1]: https://github.com/aviramradai

--- a/custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra/attributes/default.rb
+++ b/custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra/attributes/default.rb
@@ -1,0 +1,6 @@
+# default['newrelic_infra']['display_name'] = nil
+
+default["newrelic_infra"]["license_key"] = "INSERT_NEW_RELIC_INFRA_KEY"
+
+# To use the license key from the New Relic addon, please uncomment the line below:
+# default['newrelic_infra']['use_newrelic_addon'] = true

--- a/custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra/metadata.rb
+++ b/custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra/metadata.rb
@@ -1,0 +1,4 @@
+name "custom-newrelic_infra"
+version "1.0.0"
+
+depends "ey-newrelic_infra"

--- a/custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra/recipes/default.rb
+++ b/custom-cookbooks/newrelic_infra/cookbooks/custom-newrelic_infra/recipes/default.rb
@@ -1,0 +1,1 @@
+include_recipe "ey-newrelic_infra"

--- a/custom-cookbooks/newrelic_infra/cookbooks/ey-custom/metadata.rb
+++ b/custom-cookbooks/newrelic_infra/cookbooks/ey-custom/metadata.rb
@@ -1,0 +1,4 @@
+name "ey-custom"
+version "1.0.0"
+
+depends "custom-newrelic_infra"

--- a/custom-cookbooks/newrelic_infra/cookbooks/ey-custom/recipes/after-main.rb
+++ b/custom-cookbooks/newrelic_infra/cookbooks/ey-custom/recipes/after-main.rb
@@ -1,0 +1,1 @@
+include_recipe "custom-newrelic_infra"


### PR DESCRIPTION
**Description of your patch**
Adds support for New Relic Infra by migrating recipe from v6 to v7

**Recommended Release Notes**
Added support for New Relic Infra

**Estimated risk**
Medium

**Components involved**
`cookbooks/ey-newrelic_infra`
`custom-cookbooks/newrelic_infra`


**Description of testing done**

* Create a new environment with v7 as stack
* Upload recipe for `cookbooks/ey-newrelic_infra` and `custom-cookbooks/newrelic_infra`
* Verify through the chef logs that ey-newrelic_infra recipe has been executed
* Verify if New Relic Package has been successfully installed

**QA Instructions**

* Create a new environment with v7 as stack
* Upload recipe for `cookbooks/ey-newrelic_infra` and `custom-cookbooks/newrelic_infra`
* Verify through the chef logs that ey-newrelic_infra recipe has been executed
* Verify if New Relic Package has been successfully installed