### PR TITLE
[FBZ-10416] Add code to remove auto.cnf on mysql slave instance

### DIFF
--- a/cookbooks/ey-mysql/resources/mysql_slave.rb
+++ b/cookbooks/ey-mysql/resources/mysql_slave.rb
@@ -108,9 +108,9 @@ action :action_mysql_slave do
 
   # the master writes it's uuid to <datadir>/auto.cnf, the slave needs that removed so it will gen it's own
   file "#{node['mysql']['datadir']}/auto.cnf" do
-     action :delete
-     Chef::Log.info("removing <datadir>/auto.cnf")
-     only_if { node["mysql"]["short_version"] >= "5.6" }   
+    action :delete
+    Chef::Log.info("removing <datadir>/auto.cnf")
+    only_if { node["mysql"]["short_version"] >= "5.6" }
   end
 
   include_recipe "ey-mysql::startup"

--- a/cookbooks/ey-mysql/resources/mysql_slave.rb
+++ b/cookbooks/ey-mysql/resources/mysql_slave.rb
@@ -110,7 +110,7 @@ action :action_mysql_slave do
   file "#{node['mysql']['datadir']}/auto.cnf" do
      action :delete
      Chef::Log.info("removing <datadir>/auto.cnf")
-     only_if { node['mysql']['short_version'] >= '5.6' }   
+     only_if { node["mysql"]["short_version"] >= "5.6" }   
   end
 
   include_recipe "ey-mysql::startup"

--- a/cookbooks/ey-mysql/resources/mysql_slave.rb
+++ b/cookbooks/ey-mysql/resources/mysql_slave.rb
@@ -107,12 +107,10 @@ action :action_mysql_slave do
   end
 
   # the master writes it's uuid to <datadir>/auto.cnf, the slave needs that removed so it will gen it's own
-  execute "remove auto.cnf" do
-    cwd node['mysql']['datadir']
-    command "rm -f #{node['mysql']['datadir']}/auto.cnf"
-    only_if { node['mysql']['short_version'] >= '5.6' }
-  end
-
+  file "#{node['mysql']['datadir']}/auto.cnf" do
+        action :delete
+        Chef::Log.info("removing <datadir>/auto.cnf")
+      end
 
   include_recipe "ey-mysql::startup"
 

--- a/cookbooks/ey-mysql/resources/mysql_slave.rb
+++ b/cookbooks/ey-mysql/resources/mysql_slave.rb
@@ -106,6 +106,14 @@ action :action_mysql_slave do
     only_if { !Dir.glob("#{node['mysql']['datadir']}/slave-relay*").empty? && !volume_from_slave_snapshot }
   end
 
+  # the master writes it's uuid to <datadir>/auto.cnf, the slave needs that removed so it will gen it's own
+  execute "remove auto.cnf" do
+    cwd node['mysql']['datadir']
+    command "rm -f #{node['mysql']['datadir']}/auto.cnf"
+    only_if { node['mysql']['short_version'] >= '5.6' }
+  end
+
+
   include_recipe "ey-mysql::startup"
 
   template "/tmp/clear_binlogs_from_slave.sh" do

--- a/cookbooks/ey-mysql/resources/mysql_slave.rb
+++ b/cookbooks/ey-mysql/resources/mysql_slave.rb
@@ -108,9 +108,10 @@ action :action_mysql_slave do
 
   # the master writes it's uuid to <datadir>/auto.cnf, the slave needs that removed so it will gen it's own
   file "#{node['mysql']['datadir']}/auto.cnf" do
-        action :delete
-        Chef::Log.info("removing <datadir>/auto.cnf")
-      end
+     action :delete
+     Chef::Log.info("removing <datadir>/auto.cnf")
+     only_if { node['mysql']['short_version'] >= '5.6' }   
+  end
 
   include_recipe "ey-mysql::startup"
 


### PR DESCRIPTION
**Description of your patch**
Updated `resources/mysql_slave.rb` to remove auto.cnf on slave.  

**Recommended Release Notes:**
Fixed MySQS recipe for removal of auto.cnf on MySQL slave to get replication on. 

**Estimated risk**
High

**Components involved**

ey-mysql

**Dependencies**
none

**Description of testing done**

* Boot Environment with Stack-v7 and MySQL as database.
* Try to boot a slave instance and check mysql replication is successful. 

**QA Instructions**

* Boot Environment with Stack-v7 and MySQL as database.
* Try to boot a slave instance and an check for mysql replication by running `show slave status\G;` on mysql console. 
 