### PR TITLE
Fbz 10459 puma not restarted on deploy

### DIFF
--- a/cookbooks/ey-puma/templates/default/app_control.erb
+++ b/cookbooks/ey-puma/templates/default/app_control.erb
@@ -54,7 +54,7 @@ deploy() {
 stop() {
   if is_running ; then
     echo "Stopping Puma for ${application} ..."
-    systemctl stop puma_<%= @app_name %>
+    systemctl stop puma_<%= @app_name %>.socket puma_<%= @app_name %>.service
     exit 1
   else
     echo "ERROR: Doesn't seem puma is running for <%= @app_name %>"
@@ -63,7 +63,7 @@ stop() {
 }
 
 restart() {
-  systemctl restart puma_<%= @app_name %>.socket
+  systemctl restart puma_<%= @app_name %>.socket puma_<%= @app_name %>.service
 }
 
 
@@ -80,11 +80,14 @@ case "$ACTION" in
   status)
     status
     ;;
-  restart)
+  hot_restart)
     deploy
     ;;
+  hard_restart)
+    restart
+    ;;
   *)
-    echo "Usage: $0 {start|stop|status|restart|deploy}"
+    echo "Usage: $0 {start|stop|status|hot_restart|hart_restart|deploy}"
     exit 1
     ;;
 esac

--- a/cookbooks/ey-puma/templates/default/app_control.erb
+++ b/cookbooks/ey-puma/templates/default/app_control.erb
@@ -44,7 +44,7 @@ deploy() {
     if is_running ; then
       echo "Hot deploying Puma for ${application} on port $PORT (pid: ${current_pid}) ..."
       cd ${current_path}
-      pumactl -S --state /var/run/engineyard/<%= @app_name %>/puma_<%= @app_name %>.state restart && echo " hot deploy in progress."
+      pumactl -S  /var/run/engineyard/<%= @app_name %>/puma_<%= @app_name %>.state restart && echo " hot deploy in progress."
     else
       start
     fi
@@ -63,7 +63,7 @@ stop() {
 }
 
 restart() {
-  systemctl restart puma_<%= @app_name %>.socket puma_<%= @app_name %>.service
+  systemctl restart puma_<%= @app_name %>.socket
 }
 
 

--- a/cookbooks/ey-puma/templates/default/app_control.erb
+++ b/cookbooks/ey-puma/templates/default/app_control.erb
@@ -41,7 +41,7 @@ start() {
 
 deploy() {
     if is_running ; then
-      echo "Hot deploying Puma for ${application} on port $PORT (pid: ${current_pid}) ..."
+      echo "Hot deploying Puma for ${application}"
       cd ${current_path}
       pumactl -S  /var/run/engineyard/<%= @app_name %>/puma_<%= @app_name %>.state restart && echo " hot deploy in progress."
     else

--- a/cookbooks/ey-puma/templates/default/app_control.erb
+++ b/cookbooks/ey-puma/templates/default/app_control.erb
@@ -87,7 +87,7 @@ case "$ACTION" in
     restart
     ;;
   *)
-    echo "Usage: $0 {start|stop|status|hot_restart|hart_restart|deploy}"
+    echo "Usage: $0 {start|stop|status|hot_restart|hard_restart|deploy}"
     exit 1
     ;;
 esac

--- a/cookbooks/ey-puma/templates/default/app_control.erb
+++ b/cookbooks/ey-puma/templates/default/app_control.erb
@@ -40,7 +40,6 @@ start() {
 }
 
 deploy() {
-  for PORT in <%= @port %>; do
     if is_running ; then
       echo "Hot deploying Puma for ${application} on port $PORT (pid: ${current_pid}) ..."
       cd ${current_path}
@@ -48,7 +47,6 @@ deploy() {
     else
       start
     fi
-  done
 }
 
 stop() {

--- a/cookbooks/ey-puma/templates/default/puma.service.erb
+++ b/cookbooks/ey-puma/templates/default/puma.service.erb
@@ -25,7 +25,7 @@ User=<%= @username %>
 
 WorkingDirectory=/data/<%= @app %>/current
 
-ExecStart=/data/<%= @app %>/current/ey_bundler_binstubs/puma -w <%= @workers %>:<%= @workers %> -e <%= @framework_env %> --bind unix:///var/run/engineyard/<%= @app %>/puma_<%= @app %>.sock --port <%= @port %> --control-url unix:///var/run/engineyard/<%= @app %>/puma_<%= @app %>-ctl.sock --state /var/run/engineyard/<%= @app %>/puma_<%= @app %>.state
+ExecStart=/data/<%= @app %>/current/ey_bundler_binstubs/puma -w <%= @workers %>:<%= @workers %> -e <%= @framework_env %> --bind unix:///var/run/engineyard/<%= @app %>/puma_<%= @app %>.sock --port <%= @port %> --control-url unix:///var/run/engineyard/<%= @app %>/puma_<%= @app %>-ctl.sock --state /var/run/engineyard/<%= @app %>/puma_<%= @app %>.state --dir /data/<%= @app %>/current/ --prune-bundler
 
 Restart=always
 


### PR DESCRIPTION
**Description of your patch**
Updated cookbooks/ey-puma/templates/default/app_control.erb to support hot restart on deploy and hot and hard restarts 

**Recommended Release Notes:**
Fix for puma restart on deploy 

**Estimated risk**
High

**Components involved**

ey-puma

**Dependencies**
none

**Description of testing done**

Booted Environment with Stack-v7 and puma as application stack, 
Try to deploy application and see application workers are restarts and load new config , try running `/engineyard/bin/app_appname hot_restart` and `/engineyard/bin/app_appname  hard_restart `

**QA Instructions**

Boot Environment with Stack-v7 and puma as application stack, 
Try to deploy application and see application workers are restarts and load new config , try running `/engineyard/bin/app_appname hot_restart` and `/engineyard/bin/app_appname  hard_restart `
