### PR TITLE
[FbZ 10462] environment variables without export

### DIFF
--- a/cookbooks/ey-env_vars/recipes/cloud.rb
+++ b/cookbooks/ey-env_vars/recipes/cloud.rb
@@ -12,5 +12,13 @@ if ["solo", "app", "app_master", "util"].include?(node["dna"]["instance_role"])
       variables(environment_variables: fetch_environment_variables(app_data))
       helpers(EnvVars::Helper)
     end
+    template "/data/#{app_name}/shared/config/env.systemctl" do
+      source "env.systemctl.erb"
+      owner ssh_username
+      group ssh_username
+      mode "0744"
+      variables(environment_variables: fetch_environment_variables(app_data))
+      helpers(EnvVars::Helper)
+    end
   end
 end

--- a/cookbooks/ey-env_vars/templates/default/env.systemctl.erb
+++ b/cookbooks/ey-env_vars/templates/default/env.systemctl.erb
@@ -1,0 +1,7 @@
+<% @environment_variables.reject{|varname| varname[:name] =~ /^EY_/}.each do |variable| %>
+<% if node['dna']['applications'].first[1]['type'] == "php" then %>
+env[<%= variable[:name] %>]="<%= escape_variable_value(variable[:value]) %>"
+<% else %>
+<%= variable[:name] %>="<%= escape_variable_value(variable[:value]) %>"
+<% end %>
+<% end %>

--- a/cookbooks/ey-puma/templates/default/app_control.erb
+++ b/cookbooks/ey-puma/templates/default/app_control.erb
@@ -8,7 +8,7 @@
 source /etc/profile
 source /data/<%= @app_name %>/shared/config/env
 <% if @customvar %>
-source /data/<%= @app_name %>/shared/config/env.custom
+source /data/<%= @app_name %>/shared/config/env.systemctl
 <% end %>
 <% if @cloudvar %>
 source /data/<%= @app_name %>/shared/config/env.cloud

--- a/cookbooks/ey-puma/templates/default/app_control.erb
+++ b/cookbooks/ey-puma/templates/default/app_control.erb
@@ -8,10 +8,10 @@
 source /etc/profile
 source /data/<%= @app_name %>/shared/config/env
 <% if @customvar %>
-source /data/<%= @app_name %>/shared/config/env.systemctl
+source /data/<%= @app_name %>/shared/config/env.custom
 <% end %>
 <% if @cloudvar %>
-source /data/<%= @app_name %>/shared/config/env.cloud
+source /data/<%= @app_name %>/shared/config/env.systemctl
 <% end %>
 
 


### PR DESCRIPTION
**Description of your patch**
Updated `cookbooks/ey-env_vars/recipes/cloud.rb` to save environmnet variables saved without export in `env.systemctl` and puma app control script load this instead of `env.cloud`

**Recommended Release Notes:**
Fix for envionrment variables in puma. 

Estimated risk
High

**Components involved**

ey-puma
ey-env_vars

**Dependencies**
none

**Description of testing done**

- Booted Environment with Stack-v7 and puma as application stack
- Add environment variables.  
- Tried to restart application using `/engineyard/bin/app_appname hot_restart` or  `/engineyard/bin/app_appname hard_restart` and no error logged for environment variables in `var/log/syslog` sample message `Ignoring invalid environment assignment 'export` 

**QA Instructions**

- Booted Environment with Stack-v7 and puma as application stack
- Add environment variables.  
- Try to restart application using `/engineyard/bin/app_appname hot_restart` or  `/engineyard/bin/app_appname hard_restart` and see if any error logged for environment variables in `var/log/syslog` sample message `Ignoring invalid environment assignment 'export` 