### PR TITLE
[FBZ-10467] Incorrect worker count calculation for puma

### DIFF
--- a/cookbooks/ey-puma/templates/default/puma.service.erb
+++ b/cookbooks/ey-puma/templates/default/puma.service.erb
@@ -25,7 +25,7 @@ User=<%= @username %>
 
 WorkingDirectory=/data/<%= @app %>/current
 
-ExecStart=/data/<%= @app %>/current/ey_bundler_binstubs/puma -w <%= @workers %>:<%= @workers %> -e <%= @framework_env %> --bind unix:///var/run/engineyard/<%= @app %>/puma_<%= @app %>.sock --port <%= @port %> --control-url unix:///var/run/engineyard/<%= @app %>/puma_<%= @app %>-ctl.sock --state /var/run/engineyard/<%= @app %>/puma_<%= @app %>.state --dir /data/<%= @app %>/current/
+ExecStart=/data/<%= @app %>/current/ey_bundler_binstubs/puma -w <%= @workers %>:<%= @threads %> -e <%= @framework_env %> --bind unix:///var/run/engineyard/<%= @app %>/puma_<%= @app %>.sock --port <%= @port %> --control-url unix:///var/run/engineyard/<%= @app %>/puma_<%= @app %>-ctl.sock --state /var/run/engineyard/<%= @app %>/puma_<%= @app %>.state --dir /data/<%= @app %>/current/
 
 Restart=always
 


### PR DESCRIPTION
**Description of your patch**
fixed worker and threads definition on systemctl service 

**Recommended Release Notes**
fixed puma worker and threads calculation. 

**Estimated risk**
Medium

**Components involved**
ey-puma

**Dependencies**
none

**Description of testing done**

Create a new environment with v7 as stack, with application stack as puma. 
Added overlay recipe for the fix.
Verified the worker and threads definition in /usr/lib/systemd/system/puma_app.service on app instances.
. 
**QA Instructions**

Create a new environment with v7 as stack, with application stack as puma. 
Added overlay recipe for the fix.
Verified the worker and threads definition in /usr/lib/systemd/system/puma_app.service on app instances.
