### PR TITLE
[FbZ 10462] environment variables without export (Corrections)

### DIFF
--- a/cookbooks/ey-puma/recipes/default.rb
+++ b/cookbooks/ey-puma/recipes/default.rb
@@ -60,7 +60,7 @@ node.engineyard.apps.each_with_index do |app, index|
               app_dir: "#{app_path}/current",
               deploy_file: deploy_file,
               shared_path: "#{app_path}/shared",
-              cloudvar: ::File.exist?("/data/#{app.name}/shared/config/env.systemctl"),
+              cloudvar: ::File.exist?("/data/#{app.name}/shared/config/env.cloud"),
               customvar: ::File.exist?("/data/#{app.name}/shared/config/env.custom"),
               framework_env: framework_env)
   end
@@ -83,7 +83,7 @@ node.engineyard.apps.each_with_index do |app, index|
               workers: workers,
               threads: threads,
               port: port,
-              cloudvar: ::File.exist?("/data/#{app.name}/shared/config/env.systemctl"),
+              systemctlvar: ::File.exist?("/data/#{app.name}/shared/config/env.systemctl"),
               customvar: ::File.exist?("/data/#{app.name}/shared/config/env.custom"))
     notifies :run, "execute[reload-systemd]"
   end

--- a/cookbooks/ey-puma/recipes/default.rb
+++ b/cookbooks/ey-puma/recipes/default.rb
@@ -60,7 +60,7 @@ node.engineyard.apps.each_with_index do |app, index|
               app_dir: "#{app_path}/current",
               deploy_file: deploy_file,
               shared_path: "#{app_path}/shared",
-              cloudvar: ::File.exist?("/data/#{app.name}/shared/config/env.cloud"),
+              cloudvar: ::File.exist?("/data/#{app.name}/shared/config/env.systemctl"),
               customvar: ::File.exist?("/data/#{app.name}/shared/config/env.custom"),
               framework_env: framework_env)
   end
@@ -83,7 +83,7 @@ node.engineyard.apps.each_with_index do |app, index|
               workers: workers,
               threads: threads,
               port: port,
-              cloudvar: ::File.exist?("/data/#{app.name}/shared/config/env.cloud"),
+              cloudvar: ::File.exist?("/data/#{app.name}/shared/config/env.systemctl"),
               customvar: ::File.exist?("/data/#{app.name}/shared/config/env.custom"))
     notifies :run, "execute[reload-systemd]"
   end

--- a/cookbooks/ey-puma/templates/default/app_control.erb
+++ b/cookbooks/ey-puma/templates/default/app_control.erb
@@ -11,7 +11,7 @@ source /data/<%= @app_name %>/shared/config/env
 source /data/<%= @app_name %>/shared/config/env.custom
 <% end %>
 <% if @cloudvar %>
-source /data/<%= @app_name %>/shared/config/env.systemctl
+source /data/<%= @app_name %>/shared/config/env.cloud
 <% end %>
 
 

--- a/cookbooks/ey-puma/templates/default/puma.service.erb
+++ b/cookbooks/ey-puma/templates/default/puma.service.erb
@@ -9,7 +9,7 @@ Type=notify
 
 EnvironmentFile=/data/<%= @app %>/shared/config/env
 
-<% if @cloudvar %>
+<% if @systemctlvar %>
 EnvironmentFile=/data/<%= @app %>/shared/config/env.systemctl
 <% end %>
 <% if @customvar %>

--- a/cookbooks/ey-puma/templates/default/puma.service.erb
+++ b/cookbooks/ey-puma/templates/default/puma.service.erb
@@ -10,7 +10,7 @@ Type=notify
 EnvironmentFile=/data/<%= @app %>/shared/config/env
 
 <% if @cloudvar %>
-EnvironmentFile=/data/<%= @app %>/shared/config/env.cloud
+EnvironmentFile=/data/<%= @app %>/shared/config/env.systemctl
 <% end %>
 <% if @customvar %>
 EnvironmentFile=/data/<%= @app %>/shared/config/env.custom


### PR DESCRIPTION
**Description of your patch**
Added environment variable BUNDLE_GEMFILE="" so that puma can load gem file changes on deloy

**Recommended Release Notes**
fixed puma to load gemfile changes on deploy

**Estimated risk**
Medium

**Components involved**
ey-puma

**Dependencies**
none

**Description of testing done**

- Create a new environment with v7 as stack, with application stack as puma.
- Added overlay recipe for the fix.
- Verified the environment variable being set in file /data/app/current/config/env.systemctl without export and try loading app using  `. /data/app_name/shared/config/env.systemctl && bundle exec rails console` and run `printenv` to list output for all env vars.  

**QA Instructions**

- Create a new environment with v7 as stack, with application stack as puma.
- Added overlay recipe for the fix.
- Verified the environment variable being set in file /data/app/current/config/env.systemctl without export and try loading app using  `. /data/app_name/shared/config/env.systemctl && bundle exec rails console` and run `printenv` to list output for all env vars