### PR TITLE
[FBZ10472] Addresses issue of sidekiq running as root by using SSH_USER

### DIFF
--- a/cookbooks/ey-sidekiq/metadata.rb
+++ b/cookbooks/ey-sidekiq/metadata.rb
@@ -1,4 +1,4 @@
 name "ey-sidekiq"
-version "1.0.0"
+version "1.0.1"
 
 depends "ey-lib"

--- a/cookbooks/ey-sidekiq/recipes/setup.rb
+++ b/cookbooks/ey-sidekiq/recipes/setup.rb
@@ -21,6 +21,7 @@ if node["sidekiq"]["is_sidekiq_instance"]
         variables(
           app_name: app_name,
           count: count,
+          user: node.engineyard.environment.ssh_username,
           rails_env: node["dna"]["environment"]["framework_env"],
           memory_limit: node["sidekiq"]["worker_memory"]
         )

--- a/cookbooks/ey-sidekiq/templates/default/sidekiq.service.erb
+++ b/cookbooks/ey-sidekiq/templates/default/sidekiq.service.erb
@@ -7,8 +7,8 @@ Type=simple
 WorkingDirectory=/data/<%= @app_name %>/current
 ExecStart=/bin/bash -lc "bundle exec sidekiq -e <%= @rails_env %> -C /data/<%= @app_name %>/current/config/sidekiq_<%= @count %>.yml"
 
-User=root
-Group=root
+User=<%= @user %>
+Group=<%= @user %>
 RestartSec=30
 Restart=on-failure
 


### PR DESCRIPTION
Description of your patch
Sidekiq change from running as root back to customer user

Recommended Release Notes
Changed how sidekiq is ran

Estimated risk
Low

Components involved
ey-sidekiq

Dependencies
none

Description of testing done
Ran through linter and followed QA instructions


QA Instructions

* Create a new environment with v7 as stack
* Enable Sidekiq
* Deploy an application with sidekiq
* Check sidekiq is running under custom user not root
