### PR TITLE
[FBZ-10466] Custom-Redis cookbook added

### DIFF
--- a/cookbooks/ey-redis/attributes/default.rb
+++ b/cookbooks/ey-redis/attributes/default.rb
@@ -1,7 +1,8 @@
 default["redis"].tap do |redis|
   # Installing from APT (the default) is the recommended approach.
   # Set install_from_source to true if you need a version
-  # that's different from the one offered by Ubuntu 18.04.
+  # that's different from the one offered by Ubuntu 20.04.
+  # As per now the default version is 5.0.7-2ubuntu0.1
   redis["install_from_source"] = false
 
   # If you're installing from source, see http://download.redis.io/releases/ for the available versions

--- a/custom-cookbooks/redis/README.md
+++ b/custom-cookbooks/redis/README.md
@@ -1,0 +1,93 @@
+## Optional Cookbook for Engine Yard Cloud
+
+# Custom-Redis
+
+This example contains a `cookbooks/` directory to consume the `ey-redis` cookbook for
+the V7 stack.
+
+[Redis][1] Redis is an open source, advanced key-value store. It is often referred to as a data structure server since keys can contain [strings][7], [hashes][6], [lists][5], [sets][4] and [sorted sets][3].  Learn More at the [introduction][7].
+
+## Overview
+
+This cookbook provides a method to host a dedicated redis instance.  This recipe should *NOT* be used on your Database instance as it is not designed for that instance.  Additionally it will not change nor modify your database instance in anyway what so ever.
+
+## Installation
+
+Since this is an optional recipe, it should be installed by simply including it via a `depends` in your `ey-custom/metadata.rb` file and an `include_recipe` in the appropriate hook file. For more details on optional recipes see the [redis example]. (Yes, how convenient that the example is for the exact recipe you wanted)
+
+This recipe will only activate on instances with the exact name `redis`.
+
+## Design
+
+* 1+ utility instances
+* over-commit is enabled by default to ensure the least amount of problems saving your database.
+* 64-bit is required for storing over 2gigabytes worth of keys.
+* /etc/hosts mapping for `redis-instance` so that a hard config can be used to connect
+
+## Backups
+
+This cookbook does not automate nor facilitate any backup method currently.  By default there is a snapshot enabled for your environment and that should provide a viable backup to recover from.  If you have any backup concerns open a ticket with our [Support Team][9].
+
+
+## Changing Defaults
+
+A large portion of the defaults of this recipe have been moved to a attribute file; if you need to change how often you save; review the attribute file and modify.
+
+### Installing on Solo
+
+In order to run redis on a solo environment (Not Recommended), you may consider editting `attributes.rb` with the followings:
+
+Commenting out the following block,
+```
+    redis["utility_name"] = fetch_env_var(node, "EY_REDIS_INSTANCE_NAME", "redis")
+    redis_instances << redis["utility_name"]
+    redis["is_redis_instance"] = (
+      node["dna"]["instance_role"] == fetch_env_var(node, "EY_REDIS_INSTANCE_ROLE", "util") &&
+      redis_instances.include?(node["dna"]["name"])
+    )
+```
+
+and uncommenting: 
+```
+    redis['is_redis_instance'] = (node['dna']['instance_role'] == 'solo')
+```
+
+## Choosing a different Redis version
+
+This recipe installs Redis `5.0.7-2ubuntu0.1`, which is the Ubuntu 20.04 default version.
+
+To install a different version of Redis, set `:install_from_source` to true,
+override the `:version` attribute, and set the correct `:download_url`.
+You can do this with a new file in `cooobooks/ey-redis/attributes`
+such as `overrides.rb` which sets the attribute like so:
+
+```
+  node['redis']['install_from_source'] = true
+  node['redis']['version'] = '5.0-r6'
+  node['redis']['download_url'] = "https://github.com/antirez/redis/archive/#{node['redis']['version']}.tar.gz"
+```
+
+## Notes
+
+1. Please be aware these are default config files and will likely need to be updated :)
+2. This recipe will put in place a `redis.yml` on `/data/{app_name}/shared/config/`.
+
+## How to get Support
+
+* irc://irc.freenode.net/#redis
+* This Github repository.
+* This Cookbook provides a technology that is listed in the Engine Yard [Technology Stack][2]
+
+[1]: http://redis.io/
+[2]: http://www.engineyard.com/products/technology/stack
+[3]: http://redis.io/topics/data-types#sorted-sets
+[4]: http://redis.io/topics/data-types#sets
+[5]: http://redis.io/topics/data-types#lists
+[6]: http://redis.io/topics/data-types#hashes
+[7]: http://redis.io/topics/data-types#strings
+[8]: http://redis.io/topics/introduction
+[9]: https://support.cloud.engineyard.com
+
+
+See [cookbooks/ey-redis](cookbooks/ey-redis/README.md) for complete
+instructions.

--- a/custom-cookbooks/redis/cookbooks/custom-redis/attributes/default.rb
+++ b/custom-cookbooks/redis/cookbooks/custom-redis/attributes/default.rb
@@ -1,108 +1,102 @@
 default["redis"].tap do |redis|
-    # Installing from APT (the default) is the recommended approach.
-    # Set install_from_source to true if you need a version
-    # that's different from the one offered by Ubuntu 20.04.
-    # As per now the default version is 5.0.7-2ubuntu0.1
-    redis["install_from_source"] = false
-  
-    # If you're installing from source, see http://download.redis.io/releases/ for the available versions
-    # Beta versions will also work, e.g. 5.0-rc6. Make sure you set the download_url correctly.
-    # redis['install_from_source'] = true
-    # redis['version'] = '4.0.11'
-    # redis['download_url'] = "http://download.redis.io/releases/redis-#{redis['version']}.tar.gz"
-  
-    # Redis Beta, if you really have to
-    # Make sure you also set redis['install_from_source'] to true
-    # redis['install_from_source'] = true
-    # redis['version'] = '5.0-rc6'
-    # redis['download_url'] = "https://github.com/antirez/redis/archive/#{redis['version']}.tar.gz"
-  
-    # If EY_REDIS_VERSION is set, install (from source) that particular version
-    ey_redis_version = fetch_env_var(node, "EY_REDIS_VERSION")
-    if ey_redis_version
-      ey_redis_version.strip!
-      redis["install_from_source"] = true
-      redis["version"] = ey_redis_version
-      redis["download_url"] = "https://github.com/antirez/redis/archive/#{redis['version']}.tar.gz"
-    end
-  
-    redis["force_upgrade"] = fetch_env_var(node, "EY_REDIS_FORCE_UPGRADE", false)
-  
-    redis["port"] = "6379"
-    redis["basedir"] = "/data/redis"
-  
-    # Collect the redis instances in this array
-    redis_instances = []
-  
-    # Configure a Redis slave instance
-    # redis['slave_name'] = 'redis_slave'
-    # redis_instances << redis['slave_name']
-  
-    # Run Redis on a named util instance
-    # This is the default
-    redis["utility_name"] = fetch_env_var(node, "EY_REDIS_INSTANCE_NAME", "redis")
-    redis_instances << redis["utility_name"]
-    redis["is_redis_instance"] = (
-      node["dna"]["instance_role"] == fetch_env_var(node, "EY_REDIS_INSTANCE_ROLE", "util") &&
-      redis_instances.include?(node["dna"]["name"])
-    )
-  
-    # Run redis on a solo instance
-    # Not recommended for production environments
-    # redis['is_redis_instance'] = (node['dna']['instance_role'] == 'solo')
-  
-    # Log level options:
-    # - debug
-    # - verbose
-    # - notice
-    # - warning
-    redis["loglevel"] = "notice"
-    redis["logfile"] = "/data/redis/redis.log"
-  
-    # Timeout
-    redis["timeout"] = 300000
-  
-    # Where to save the RDB file
-    redis["rdb_filename"] = "dump.rdb"
-  
-    # Save frequency
-    #
-    # In the example below the behaviour will be to save:
-    # after 900 sec (15 min) if at least 1 key changed
-    # after 300 sec (5 min) if at least 10 keys changed
-    # after 60 sec if at least 10000 keys changed
-    redis["saveperiod"] = [
-      "900 1",
-      "300 10",
-      "60 10000",
-    ]
-  
-    # Set the number of databases. The default database is DB 0, you can select
-    # a different one on a per-connection basis using SELECT <dbid> where
-    # dbid is a number between 0 and 'databases'-1
-    redis["databases"] = 16
-  
-    # Compress string objects using LZF when dump .rdb databases?
-    # For default that's set to 'yes' as it's almost always a win.
-    # If you want to save some CPU in the saving child set it to 'no' but
-    # the dataset will likely be bigger if you have compressible values or keys.
-    redis["rdbcompression"] = "yes"
-  
-    # Redis calls an internal function to perform many background tasks, like
-    # closing connections of clients in timeout, purging expired keys that are
-    # never requested, and so forth.
-    #
-    # Not all tasks are performed with the same frequency, but Redis checks for
-    # tasks to perform according to the specified "hz" value.
-    #
-    # By default "hz" is set to 10. Raising the value will use more CPU when
-    # Redis is idle, but at the same time will make Redis more responsive when
-    # there are many keys expiring at the same time, and timeouts may be
-    # handled with more precision.
-    #
-    # The range is between 1 and 500, however a value over 100 is usually not
-    # a good idea. Most users should use the default of 10 and raise this up to
-    # 100 only in environments where very low latency is required.
-    redis["hz"] = 10
+  # Installing from APT (the default) is the recommended approach.
+  # Set install_from_source to true if you need a version
+  # that's different from the one offered by Ubuntu 20.04.
+  # As per now the default version is 5.0.7-2ubuntu0.1
+  redis["install_from_source"] = false
+  # If you're installing from source, see http://download.redis.io/releases/ for the available versions
+  # Beta versions will also work, e.g. 5.0-rc6. Make sure you set the download_url correctly.
+  # redis['install_from_source'] = true
+  # redis['version'] = '4.0.11'
+  # redis['download_url'] = "http://download.redis.io/releases/redis-#{redis['version']}.tar.gz"
+
+  # Redis Beta, if you really have to
+  # Make sure you also set redis['install_from_source'] to true
+  # redis['install_from_source'] = true
+  # redis['version'] = '5.0-rc6'
+  # redis['download_url'] = "https://github.com/antirez/redis/archive/#{redis['version']}.tar.gz"
+  # If EY_REDIS_VERSION is set, install (from source) that particular version
+  ey_redis_version = fetch_env_var(node, "EY_REDIS_VERSION")
+  if ey_redis_version
+    ey_redis_version.strip!
+    redis["install_from_source"] = true
+    redis["version"] = ey_redis_version
+    redis["download_url"] = "https://github.com/antirez/redis/archive/#{redis['version']}.tar.gz"
   end
-  
+
+  redis["force_upgrade"] = fetch_env_var(node, "EY_REDIS_FORCE_UPGRADE", false)
+
+  redis["port"] = "6379"
+  redis["basedir"] = "/data/redis"
+
+  # Collect the redis instances in this array
+  redis_instances = []
+
+  # Configure a Redis slave instance
+  # redis['slave_name'] = 'redis_slave'
+  # redis_instances << redis['slave_name']
+
+  # Run Redis on a named util instance
+  # This is the default
+  redis["utility_name"] = fetch_env_var(node, "EY_REDIS_INSTANCE_NAME", "redis")
+  redis_instances << redis["utility_name"]
+  redis["is_redis_instance"] = (
+    node["dna"]["instance_role"] == fetch_env_var(node, "EY_REDIS_INSTANCE_ROLE", "util") &&
+    redis_instances.include?(node["dna"]["name"])
+  )
+
+  # Run redis on a solo instance
+  # Not recommended for production environments
+  # redis['is_redis_instance'] = (node['dna']['instance_role'] == 'solo')
+  # Log level options:
+  # - debug
+  # - verbose
+  # - notice
+  # - warning
+  redis["loglevel"] = "notice"
+  redis["logfile"] = "/data/redis/redis.log"
+
+  # Timeout
+  redis["timeout"] = 300000
+
+  # Where to save the RDB file
+  redis["rdb_filename"] = "dump.rdb"
+
+  # Save frequency
+  #
+  # In the example below the behaviour will be to save:
+  # after 900 sec (15 min) if at least 1 key changed
+  # after 300 sec (5 min) if at least 10 keys changed
+  # after 60 sec if at least 10000 keys changed
+  redis["saveperiod"] = [
+    "900 1",
+    "300 10",
+    "60 10000",
+  ]
+
+  # Set the number of databases. The default database is DB 0, you can select
+  # a different one on a per-connection basis using SELECT <dbid> where
+  # dbid is a number between 0 and 'databases'-1
+  redis["databases"] = 16
+  # Compress string objects using LZF when dump .rdb databases?
+  # For default that's set to 'yes' as it's almost always a win.
+  # If you want to save some CPU in the saving child set it to 'no' but
+  # the dataset will likely be bigger if you have compressible values or keys.
+  redis["rdbcompression"] = "yes"
+  # Redis calls an internal function to perform many background tasks, like
+  # closing connections of clients in timeout, purging expired keys that are
+  # never requested, and so forth.
+  #
+  # Not all tasks are performed with the same frequency, but Redis checks for
+  # tasks to perform according to the specified "hz" value.
+  #
+  # By default "hz" is set to 10. Raising the value will use more CPU when
+  # Redis is idle, but at the same time will make Redis more responsive when
+  # there are many keys expiring at the same time, and timeouts may be
+  # handled with more precision.
+  #
+  # The range is between 1 and 500, however a value over 100 is usually not
+  # a good idea. Most users should use the default of 10 and raise this up to
+  # 100 only in environments where very low latency is required.
+  redis["hz"] = 10
+end

--- a/custom-cookbooks/redis/cookbooks/custom-redis/attributes/default.rb
+++ b/custom-cookbooks/redis/cookbooks/custom-redis/attributes/default.rb
@@ -1,0 +1,108 @@
+default["redis"].tap do |redis|
+    # Installing from APT (the default) is the recommended approach.
+    # Set install_from_source to true if you need a version
+    # that's different from the one offered by Ubuntu 20.04.
+    # As per now the default version is 5.0.7-2ubuntu0.1
+    redis["install_from_source"] = false
+  
+    # If you're installing from source, see http://download.redis.io/releases/ for the available versions
+    # Beta versions will also work, e.g. 5.0-rc6. Make sure you set the download_url correctly.
+    # redis['install_from_source'] = true
+    # redis['version'] = '4.0.11'
+    # redis['download_url'] = "http://download.redis.io/releases/redis-#{redis['version']}.tar.gz"
+  
+    # Redis Beta, if you really have to
+    # Make sure you also set redis['install_from_source'] to true
+    # redis['install_from_source'] = true
+    # redis['version'] = '5.0-rc6'
+    # redis['download_url'] = "https://github.com/antirez/redis/archive/#{redis['version']}.tar.gz"
+  
+    # If EY_REDIS_VERSION is set, install (from source) that particular version
+    ey_redis_version = fetch_env_var(node, "EY_REDIS_VERSION")
+    if ey_redis_version
+      ey_redis_version.strip!
+      redis["install_from_source"] = true
+      redis["version"] = ey_redis_version
+      redis["download_url"] = "https://github.com/antirez/redis/archive/#{redis['version']}.tar.gz"
+    end
+  
+    redis["force_upgrade"] = fetch_env_var(node, "EY_REDIS_FORCE_UPGRADE", false)
+  
+    redis["port"] = "6379"
+    redis["basedir"] = "/data/redis"
+  
+    # Collect the redis instances in this array
+    redis_instances = []
+  
+    # Configure a Redis slave instance
+    # redis['slave_name'] = 'redis_slave'
+    # redis_instances << redis['slave_name']
+  
+    # Run Redis on a named util instance
+    # This is the default
+    redis["utility_name"] = fetch_env_var(node, "EY_REDIS_INSTANCE_NAME", "redis")
+    redis_instances << redis["utility_name"]
+    redis["is_redis_instance"] = (
+      node["dna"]["instance_role"] == fetch_env_var(node, "EY_REDIS_INSTANCE_ROLE", "util") &&
+      redis_instances.include?(node["dna"]["name"])
+    )
+  
+    # Run redis on a solo instance
+    # Not recommended for production environments
+    # redis['is_redis_instance'] = (node['dna']['instance_role'] == 'solo')
+  
+    # Log level options:
+    # - debug
+    # - verbose
+    # - notice
+    # - warning
+    redis["loglevel"] = "notice"
+    redis["logfile"] = "/data/redis/redis.log"
+  
+    # Timeout
+    redis["timeout"] = 300000
+  
+    # Where to save the RDB file
+    redis["rdb_filename"] = "dump.rdb"
+  
+    # Save frequency
+    #
+    # In the example below the behaviour will be to save:
+    # after 900 sec (15 min) if at least 1 key changed
+    # after 300 sec (5 min) if at least 10 keys changed
+    # after 60 sec if at least 10000 keys changed
+    redis["saveperiod"] = [
+      "900 1",
+      "300 10",
+      "60 10000",
+    ]
+  
+    # Set the number of databases. The default database is DB 0, you can select
+    # a different one on a per-connection basis using SELECT <dbid> where
+    # dbid is a number between 0 and 'databases'-1
+    redis["databases"] = 16
+  
+    # Compress string objects using LZF when dump .rdb databases?
+    # For default that's set to 'yes' as it's almost always a win.
+    # If you want to save some CPU in the saving child set it to 'no' but
+    # the dataset will likely be bigger if you have compressible values or keys.
+    redis["rdbcompression"] = "yes"
+  
+    # Redis calls an internal function to perform many background tasks, like
+    # closing connections of clients in timeout, purging expired keys that are
+    # never requested, and so forth.
+    #
+    # Not all tasks are performed with the same frequency, but Redis checks for
+    # tasks to perform according to the specified "hz" value.
+    #
+    # By default "hz" is set to 10. Raising the value will use more CPU when
+    # Redis is idle, but at the same time will make Redis more responsive when
+    # there are many keys expiring at the same time, and timeouts may be
+    # handled with more precision.
+    #
+    # The range is between 1 and 500, however a value over 100 is usually not
+    # a good idea. Most users should use the default of 10 and raise this up to
+    # 100 only in environments where very low latency is required.
+    redis["hz"] = 10
+  end
+  

--- a/custom-cookbooks/redis/cookbooks/custom-redis/recipes/default.rb
+++ b/custom-cookbooks/redis/cookbooks/custom-redis/recipes/default.rb
@@ -1,1 +1,1 @@
-include_recipe 'ey-redis'
+include_recipe "ey-redis"

--- a/custom-cookbooks/redis/cookbooks/custom-redis/recipes/default.rb
+++ b/custom-cookbooks/redis/cookbooks/custom-redis/recipes/default.rb
@@ -1,0 +1,1 @@
+include_recipe 'ey-redis'

--- a/custom-cookbooks/redis/cookbooks/ey-custom/metadata.rb
+++ b/custom-cookbooks/redis/cookbooks/ey-custom/metadata.rb
@@ -1,0 +1,3 @@
+name "ey-custom"
+version "1.0.0"
+depends "custom-redis"

--- a/custom-cookbooks/redis/cookbooks/ey-custom/recipes/after-main.rb
+++ b/custom-cookbooks/redis/cookbooks/ey-custom/recipes/after-main.rb
@@ -1,0 +1,1 @@
+include_recipe "custom-redis"


### PR DESCRIPTION
Description of your patch
-------------
This adds the `custom-redis` cookbook which depends on `ey-redis`. This would help the clients to configure `redis` on `solo` environments and to setup `slave` feature for `redis` instance.

Recommended Release Notes
-------------
Adds Customizations of Redis installation based on a custom-cookbook. For the time being, this adds the capacity to run redis on a more customized manner (i.e. On solo instances, add slave host feature, etc.)

Estimated risk
-------------
Medium

Components involved
-------------
`custom-redis`
`ey-redis`

Dependencies
-------------
`ey-redis`

Description of testing done
-------------
Booted a solo environment and validated installation of Redis on a solo environment
Booted a multi environment and validated the installation of Redis on master-slave manner on a multi environment

QA Instructions
-------------

* On a `solo` environment
1. Boot a solo instance
2. Copy the contents of the `custom-redis/cookbooks/` to an empty directory of choice
3. Enable installation of redis on solo environment (Solo instance precisely), and re-upload the recipes
4. See if redis is installed by `/etc/init.d/redis-server status`

* On a `multi` environment
1. Boot a multi environment with 2 `util` instances `util1` and `redis`
2. Set the `redis` slave as `util1` as per the readme.
3. Upload and re-apply the recipes
4. Check by `redis-cli info | grep ^role` if the roles are properly set.
