### PR TITLE
[FBZ-10482] EY_SOURCES_PACKAGES Repo File fix

### DIFF
--- a/cookbooks/ey-packages/recipes/default.rb
+++ b/cookbooks/ey-packages/recipes/default.rb
@@ -3,7 +3,7 @@ apt_sources.each do |apt_source|
   apt_source = JSON.parse(apt_source)
   if apt_source != {}
     Chef::Log.info "PACKAGE REPOSITORY: Adding #{apt_source['name']}"
-    apt_repository "apt_source['name']" do
+    apt_repository apt_source["name"] do
       arch apt_source["arch"] unless apt_source["arch"].nil?
       uri apt_source["uri"] unless apt_source["uri"].nil?
       components [apt_source["components"]] unless apt_source["components"].nil?


### PR DESCRIPTION
Description of your patch
------------
When using environment variable `EY_SOURCES_PACKAGES`, it creates the repo file as `'apt_source['\''name'\''].list'` instead of something like `mysql57-dev.list`

Need to update line #6 of `ey-packages/recipes/default.rb`:

From: `apt_repository "apt_sources['name']" do`
To: `apt_repository apt_sources["name"] do`

Recommended Release Notes
-----------
Fixed environment variable `EY_SOURCES_PACKAGES`

Estimated risk
------------------
Low

Components involved
----------------
All customers

Dependencies
-----------------
None

Description of testing done
------------------
* Create an solo environment using v7 as the stack
* Add environment variable below:
  * EY_SOURCES_PACKAGES - `{"name":"mysql57-dev","components":["mysql-5.7"],"key":"https://repo.mysql.com/RPM-GPG-KEY-mysql-2022","distribution":"bionic","uri":"http://repo.mysql.com/apt/ubuntu/"}`
* Click *Apply* to trigger chef run
* SSH into the instance and execute `ls /etc/apt/sources.list.d`
* Verify if `mysql57-dev.list` has been created

QA Instructions
----------------
* Create an solo environment using v7 as the stack
* Add environment variable below:
  * EY_SOURCES_PACKAGES - `{"name":"mysql57-dev","components":["mysql-5.7"],"key":"https://repo.mysql.com/RPM-GPG-KEY-mysql-2022","distribution":"bionic","uri":"http://repo.mysql.com/apt/ubuntu/"}`
* Click *Apply* to trigger chef run
* SSH into the instance and execute `ls /etc/apt/sources.list.d`
* Verify if `mysql57-dev.list` has been created