### PR TITLE
[FBZ-10487] Stops collectd using recommended packages on chef run

### DIFF
--- a/cookbooks/ey-collectd/recipes/default.rb
+++ b/cookbooks/ey-collectd/recipes/default.rb
@@ -23,7 +23,8 @@ template "/engineyard/bin/ey-alert.rb" do
   })
 end
 
-package "collectd" do
+apt_package "collectd" do
+  options "--no-install-recommends"
   notifies :stop, "service[collectd]", :immediately
 end
 


### PR DESCRIPTION
**Description of your patch**

Fixes collectd from installing recommended packages when it updates / installs on chef run, like we do when we build the image

**Estimated risk**
Low

**Components involved**
All customers

**Dependencies**
None

**Description of testing done**
Booted raw AMI from development
Checked if recommended pages were installed, they weren't
Booted up fresh QA environment with overlay

**QA Instructions**

Overlay this patch on latest QA stack 33
Boot up instances
Check if collectd works
Check if xorg stack is installed when it shouldn't be
