### PR TITLE
[FBZ-10487] Remove-desktop-packages

### DIFF
--- a/cookbooks/ey-packages/recipes/default.rb
+++ b/cookbooks/ey-packages/recipes/default.rb
@@ -27,3 +27,11 @@ install.each do |package|
     end
   end
 end
+
+Chef::Log.info "PACKAGES: Removing xserver-xorg-core, gnome-shell and gdm3* as installed on >= stack-v7.1.0.8"
+package %w(ubuntu-gnome-desktop libgdm1 xserver-xorg-core gdm3 gnome-shell xserver-xorg-legacy gnome-session gnome) do
+  action :remove
+  options "--auto-remove"
+end
+
+Chef::Log.info "CHECK PACKAGES: #{node['packages'].keys}"


### PR DESCRIPTION
### Description of your patch
Stack-v7 version < stable-v7-1.0.8 install desktop packages as xorg and gmd through Recommended packages through collectd. This is now fixed in AMI and collectd recipe https://github.com/engineyard/ey-cookbooks-stable-v7/pull/124. But we need to remove installed desktop packages from existing servers. 

### Recommended Release Notes
Removes xorg and gdm3 packages from servers, which was installed by collectd as recommended packages.

### Estimated risk
Low

### Components involved
ey-packages 
### Dependencies
None

### Description of testing done
Create an solo environment using v7-1.0.8 as the stack. 
Overlay recipe ey-packages, and run apply 
Check chef logs to see  if packages get removed and later to verify run `apt list --installed|grep xorg`

### QA Instructions
Create an solo environment using v7-1.0.8 as the stack. 
Overlay recipe ey-packages, and run apply 
Check chef logs to see  if packages get removed and later to verify run `apt list --installed|grep xorg`