### PR TITLE
[fbz-10456] puma fail to start service on instance restart

### DIFF
--- a/cookbooks/ey-puma/recipes/default.rb
+++ b/cookbooks/ey-puma/recipes/default.rb
@@ -50,6 +50,11 @@ node.engineyard.apps.each_with_index do |app, index|
               threads: threads)
   end
 
+  service "puma_#{app.name}.service" do
+    provider Chef::Provider::Service::Systemd
+    action :nothing
+  end
+
   managed_template "/engineyard/bin/app_#{app.name}" do
     source  "app_control.erb"
     owner   ssh_username
@@ -86,6 +91,7 @@ node.engineyard.apps.each_with_index do |app, index|
               systemctlvar: ::File.exist?("/data/#{app.name}/shared/config/env.systemctl"),
               customvar: ::File.exist?("/data/#{app.name}/shared/config/env.custom"))
     notifies :run, "execute[reload-systemd]"
+    notifies :enable, "service[puma_#{app.name}.service]", :immediately
   end
 
   managed_template "/lib/systemd/system/puma_#{app.name}.socket" do

--- a/cookbooks/ey-puma/templates/default/puma.service.erb
+++ b/cookbooks/ey-puma/templates/default/puma.service.erb
@@ -25,6 +25,8 @@ User=<%= @username %>
 
 WorkingDirectory=/data/<%= @app %>/current
 
+ExecStartPre=/usr/bin/sudo /usr/bin/chown -R <%= @username %>:<%= @username %> /run/engineyard/<%= @app %>
+
 ExecStart=/data/<%= @app %>/current/ey_bundler_binstubs/puma -w <%= @workers %>:<%= @threads %> -e <%= @framework_env %> --bind unix:///var/run/engineyard/<%= @app %>/puma_<%= @app %>.sock --port <%= @port %> --control-url unix:///var/run/engineyard/<%= @app %>/puma_<%= @app %>-ctl.sock --state /var/run/engineyard/<%= @app %>/puma_<%= @app %>.state --dir /data/<%= @app %>/current/
 
 Restart=always


### PR DESCRIPTION
### Description of your patch
Whenever application instance is restarted puma fail to start and restarting it manually also fail due to incorrect permissions on `/run/engineyard/ap_name`, fixed permissions on  `/run/engineyard/ap_name`and set service enable. 

### Recommended Release Notes
Fis for puma start failure on instance restart. 

### Estimated risk
high

### Components involved
ey-puma

### Dependencies
None

### Description of testing done
Create an environment 
Overlay recipe ey-puma, and run apply
Restart instance and check using `systemctl status puma_app.service` if service is enabled and puma is running 

### QA Instructions
Create an environment using
Overlay recipe ey-puma, and run apply
Restart instance and check using `systemctl status puma_app.service` if service is enabled and puma is running 
