### PR TITLE
[FBZ-10488] Postgresql installing gnome desktop packages

### DIFF
--- a/cookbooks/ey-postgresql/templates/default/install.sh.erb
+++ b/cookbooks/ey-postgresql/templates/default/install.sh.erb
@@ -15,7 +15,7 @@ if [[ -z "$PKG_VER" ]]; then
   exit 1
 fi
 echo "Installing <%= package %>"
-DEBIAN_FRONTEND=noninteractive apt install -y --allow-downgrades <%= package %>="$PKG_VER"
+DEBIAN_FRONTEND=noninteractive apt install -y --allow-downgrades --no-install-recommends <%= package %>="$PKG_VER"
 <% if package == "postgresql-#{@postgres_version}" %>
 if [[ ! -n $(systemctl status postgresql | grep "Loaded.*/etc/systemd/system/postgresql.service") ]]; then
   systemctl stop postgresql && rm -f /lib/systemd/system/postgresql.service


### PR DESCRIPTION
### Description of your patch
postgresql recipe installs gnome desktop packages as recommended packages. fix it to install postgres with  `--no-install-recommends`

### Recommended Release Notes
Fix for postgres install without recommended packages 

### Estimated risk
high

### Components involved
ey-postgresql

### Dependencies
None

### Description of testing done
Create an environment
Overlay recipe ey-postgresql, and  boot environmnet. 
Review chef logs for execution of install.sh and I did' see desktop packages like gnome get installed.

### QA Instructions
Create an environment
Overlay recipe ey-postgresql, and  boot environmnet. 
Review chef logs for execution of install.sh and see if desktop package like gnome get installed.