### PR TITLE
[fbz-10494]Postgres fail on first run chef run on instance

### DIFF
--- a/cookbooks/ey-postgresql/recipes/client_config.rb
+++ b/cookbooks/ey-postgresql/recipes/client_config.rb
@@ -9,8 +9,8 @@ template "/root/.pgpass" do
   })
 end
 
-execute "touch ~/.bash_login" do
-  action :run
+file '/root/.bash_login' do
+  action :create_if_missing
 end
 
 file "add_PGUSER_to_root_bash_login" do


### PR DESCRIPTION
### **Description of your patch**
Fix for Postgres fail on first run chef run on instance and chef run after restart


### Recommended Release Notes
Fix for postgres. first run chef run on instance and chef run after restart

### Estimated risk
high

### Components involved
ey-postgresql

### Dependencies
None

### Description of testing done

- Create an environment
- Overlay recipe ey-postgresql, and boot environmnet.
- check if chef succeed and resource file `file[/root/.bash_login] action create_if_missing (ey-postgresql::client_config line 12) ` get executed successfully 
- restart instance ad check for same 

### QA Instructions

- Create an environment
- Overlay recipe ey-postgresql, and boot environmnet.
- check if chef succeed and resource file `file[/root/.bash_login] action create_if_missing (ey-postgresql::client_config line 12) ` get executed successfully 
- restart instance ad check for same 