### PR TITLE
[FBZ-FBZ-10479] updated ey-base recipe to use ey_services_setup gem version 0.0.8pre1

### DIFF
--- a/cookbooks/ey-base/recipes/resin_gems.rb
+++ b/cookbooks/ey-base/recipes/resin_gems.rb
@@ -15,7 +15,7 @@ chef_gem "ey_cloud_server" do
 end
 
 chef_gem "ey_services_setup" do
-  version "0.0.8pre1"
+  version "0.0.8"
   compile_time false
 end
 

--- a/cookbooks/ey-base/recipes/resin_gems.rb
+++ b/cookbooks/ey-base/recipes/resin_gems.rb
@@ -15,7 +15,7 @@ chef_gem "ey_cloud_server" do
 end
 
 chef_gem "ey_services_setup" do
-  version "0.0.7"
+  version "0.0.8pre1"
   compile_time false
 end
 


### PR DESCRIPTION
### Description of your patch
use of updated ey_services_setup gem

### Recommended Release Notes
Update ey_services_setup gem to 0.0.8pre1

### Estimated risk
high

### Components involved
All Client environments running on v7 

**Dependencies**
ey-base

### Description of testing done

- Spin up a v7 environment with solo instances. 
- Deploy application and check deploy logs for `Setting up external services.` and see of that shows error 

```
 /opt/chef/embedded/lib/ruby/gems/3.0.0/gems/json-1.8.6/lib/json/common.rb:155:in `initialize': wrong number of arguments (given 2, expected 1) (ArgumentError)
```
- Upload overlay recipe for ey-base including fix is PR. 
- Run apply on environment and run deploy and search for  `Setting up external services.` and this should pass now. 

### QA Instructions
- Spin up a v7 environment with solo instances. 
- Deploy application and check deploy logs for `Setting up external services.` and see of that shows error 

```
 /opt/chef/embedded/lib/ruby/gems/3.0.0/gems/json-1.8.6/lib/json/common.rb:155:in `initialize': wrong number of arguments (given 2, expected 1) (ArgumentError)
```
- Upload overlay recipe for ey-base including fix is PR. 
- Run apply on environment and run deploy and search for  `Setting up external services.` and this should pass now. 