### PR TITLE
[FBZ-10501] Fix Passenger Ports for Multi App

### DIFF
--- a/cookbooks/ey-nginx/recipes/ruby.rb
+++ b/cookbooks/ey-nginx/recipes/ruby.rb
@@ -1,6 +1,8 @@
 is_app_master = ["app_master", "solo"].include?(node["dna"]["instance_role"]) || false
 
-ports = node["passenger5"]["port"].to_i
+base_port = node["passenger5"]["port"].to_i
+stepping = 200
+ports = base_port
 
 # Temp
 
@@ -11,6 +13,8 @@ if node.stack.match(/pumalegacy/)
 end
 
 node.engineyard.apps.each_with_index do |app, index|
+  ports = base_port + (stepping * index)
+
   if node.stack.match(/pumalegacy/)
     app_base_port = base_port + (stepping * index)
     workers = [(1.0 * get_pool_size() / node["dna"]["applications"].size).round, 1].max


### PR DESCRIPTION
Description of your patch
-------------
Fix bug on ports for Passenger 

Recommended Release Notes
-------------
Fixed issue where Passenger uses the same port for multiapp environment

Estimated risk
-------------
High

Components involved
-------------
Clients who use Passenger

Dependencies
-------------
`ey-nginx`

Description of testing done
-------------
* Create v7 environment under an app (test app 1)
* Go to test app 2
* Click on _Create New Environment_
* Click _Add to Existing Environment_
* Verify the ports for the app in `/data/nginx/servers/<test app>.conf` or `/data/nginx/servers/<test app>.ssl.conf`
* upstream should point to the ones below:
  * `server 127.0.0.1:8000;` for test app 1
  * `server 127.0.0.1:8200;` for test app 2, and so on.

QA Instructions
-------------
* Create v7 environment under an app (test app 1)
* Go to test app 2
* Click on _Create New Environment_
* Click _Add to Existing Environment_
* Verify the ports for the app in `/data/nginx/servers/<test app>.conf` or `/data/nginx/servers/<test app>.ssl.conf`
* upstream should point to the ones below:
  * `server 127.0.0.1:8000;` for test app 1
  * `server 127.0.0.1:8200;` for test app 2, and so on.