### PR TITLE
[FBZ-10503] MySQL getting re-installed on mysql slave on every chef run

### DIFF
--- a/cookbooks/ey-mysql/resources/mysql_slave.rb
+++ b/cookbooks/ey-mysql/resources/mysql_slave.rb
@@ -23,6 +23,7 @@ action :action_mysql_slave do
       system("umount /db")
       FileUtils.rmdir "/db"
     end
+    action :nothing
     only_if { ::File.exist?("/db") }
   end
 


### PR DESCRIPTION
### Description of your patch
Fix MySQL getting re-installed on mysql slave on every chef run

### Recommended Release Notes
Fixed issue where MySQL getting re-installed on mysql slave on every chef run

### Estimated risk
Low

### Components involved
Clients who use MySQL Slave 

### Dependencies
ey-mysql

### Description of testing done
Create v7 environment with MySQL 
Boot Environment with a DB slave. 
Run chef and see chef logs on DB Slave instance for `ruby_block[clean up half-done install]` and t should not get executed as default action is set to nothing.   


### QA Instructions
Create v7 environment with MySQL 
Boot Environment with a DB slave. 
Run chef and see chef logs on DB Slave instance for `ruby_block[clean up half-done install]` and t should not get executed as default action is set to nothing.   