### PR TITLE
[FBZ-10505] Switch puma to phased-restart for hot restart

### DIFF
--- a/cookbooks/ey-puma/templates/default/app_control.erb
+++ b/cookbooks/ey-puma/templates/default/app_control.erb
@@ -43,7 +43,7 @@ deploy() {
     if is_running ; then
       echo "Hot deploying Puma for ${application}"
       cd ${current_path}
-      pumactl -S  /var/run/engineyard/<%= @app_name %>/puma_<%= @app_name %>.state restart && echo " hot deploy in progress."
+      pumactl -S  /var/run/engineyard/<%= @app_name %>/puma_<%= @app_name %>.state phased-restart && echo " hot deploy in progress."
     else
       start
     fi

--- a/cookbooks/ey-puma/templates/default/app_control.erb
+++ b/cookbooks/ey-puma/templates/default/app_control.erb
@@ -43,7 +43,7 @@ deploy() {
     if is_running ; then
       echo "Hot deploying Puma for ${application}"
       cd ${current_path}
-      pumactl -S  /var/run/engineyard/<%= @app_name %>/puma_<%= @app_name %>.state phased-restart && echo " hot deploy in progress."
+      pumactl -S  /var/run/engineyard/<%= @app_name %>/puma_<%= @app_name %>.state phased-restart && echo " phased-restart deploy in progress."
     else
       start
     fi


### PR DESCRIPTION
### Description of your patch
Fix puma restart on deploy cause downtime 

### Recommended Release Notes
Fixed issue where puma restart on deploy cause downtime 

### Estimated risk
High

### Components involved
All clients who use Puma as application stack

### Dependencies
ey-puma

### Description of testing done
Create v7 environment with puma
Boot Environment. 
Run application deployment and monitor for application uptime while Application deployment  at `Restarting app servers` step. 
- Check for if there is any downtime. 
- note how long it took to finish.
- how many workers of puma was running. 


### QA Instructions
Create v7 environment with puma
Boot Environment. 
Run application deployment and monitor for application uptime while Application deployment  at `Restarting app servers` step. 
- Check for if there is any downtime. 
- note how long it took to finish.
- how many workers of puma was running. 
- We need to test for an application with gemfile updates if deploy able to load that. (working with plantoeat to test that)