### PR TITLE
[FBZ-10510]Nginx is not reloaded on Apply after updating SSL setting …

### DIFF
--- a/cookbooks/ey-haproxy/recipes/configure.rb
+++ b/cookbooks/ey-haproxy/recipes/configure.rb
@@ -1,4 +1,5 @@
-service "nginx" do
+service "force-restart-nginx" do
+  service_name "nginx"
   action :restart
   only_if "lsof -n -i :80 -i :443 | grep LISTEN | grep nginx"
 end

--- a/cookbooks/ey-haproxy/recipes/configure.rb
+++ b/cookbooks/ey-haproxy/recipes/configure.rb
@@ -1,6 +1,6 @@
-service "reload-nginx" do
+service "nginx-restart" do
   service_name "nginx"
-  action :reload
+  action :restart
   only_if "lsof -n -i :80 -i :443 | grep LISTEN | grep nginx"
 end
 

--- a/cookbooks/ey-haproxy/recipes/configure.rb
+++ b/cookbooks/ey-haproxy/recipes/configure.rb
@@ -1,6 +1,6 @@
-service "force-restart-nginx" do
+service "reload-nginx" do
   service_name "nginx"
-  action :restart
+  action :reload
   only_if "lsof -n -i :80 -i :443 | grep LISTEN | grep nginx"
 end
 


### PR DESCRIPTION
### Description of your patch
Fix Nginx is not reloaded on Apply after updating SSL setting

### Recommended Release Notes
Fixed issue where Nginx is not reloaded on Apply after updating SSL setting

### Estimated risk
High

### Components involved
Clients who update SSL

### Dependencies
ey-haproxy

### Description of testing done
Create v7 environment. 
Once booted, check for the nginx running on instance  and  SSL setting it should be `No SSL`
Change SSL setting by selecting an SSL and click `update SSL Setting` and run apply on environment.
Validate if SSL updated and check for nginx process on instance is restarted.  

### QA Instructions
Create v7 environment. 
Once booted, check for the nginx running on instance  and  SSL setting it should be `No SSL`
Change SSL setting by selecting an SSL and click `update SSL Setting` and run apply on environment.
Validate if SSL updated and check for nginx process on instance is restarted.  