### PR TITLE
[FBZ-10502] Installing postgres version > 11 using EY_POSTGRES_VERSION

### DIFF
--- a/cookbooks/ey-postgresql/README.md
+++ b/cookbooks/ey-postgresql/README.md
@@ -3,6 +3,8 @@ postgresql
 
 A chef recipe for managing the installed version of PostgreSQL server and client tools on EngineYard AppCloud. This recipe uses installs from the internal Engine Yard Portage tree (Gentoo). Includes support for installing PostgreSQL client tools for working with RDS PostgreSQL.
 
+NOTE: Whenever a new version is release, this is one of the sites/services used to analyze the changes and update the recipes.
+
 dependencies
 ============
 

--- a/cookbooks/ey-postgresql/templates/default/postgresql.conf.erb
+++ b/cookbooks/ey-postgresql/templates/default/postgresql.conf.erb
@@ -194,7 +194,7 @@ max_wal_senders = 5		# max number of walsender processes
 
 # as per chnage in postgres version 13 `wal_keep_segments` is renamed to `wal_keep_size` https://pgpedia.info/w/wal_keep_segments.html
 <% if @postgres_version >= "13.0" %>
-wal_keep_size = 128 # in logfile segments, 16MB each; 0 disables 
+wal_keep_size = 2048 # in logfile segments, 16MB each; 0 disables 
 <% else %>
 wal_keep_segments = 128 		# in logfile segments, 16MB each; 0 disables
 <% end %>

--- a/cookbooks/ey-postgresql/templates/default/postgresql.conf.erb
+++ b/cookbooks/ey-postgresql/templates/default/postgresql.conf.erb
@@ -191,7 +191,13 @@ archive_timeout = <%= @archive_timeout %>		# force a logfile segment switch afte
 
 max_wal_senders = 5		# max number of walsender processes
 #wal_sender_delay = 200ms	# walsender cycle time, 1-10000 milliseconds
+
+# as per chnage in postgres version 13 `wal_keep_segments` is renamed to `wal_keep_size` https://pgpedia.info/w/wal_keep_segments.html
+<% if @postgres_version >= "13.0" %>
+wal_keep_size = 128 # in logfile segments, 16MB each; 0 disables 
+<% else %>
 wal_keep_segments = 128 		# in logfile segments, 16MB each; 0 disables
+<% end %>
 #vacuum_defer_cleanup_age = 0	# number of xacts by which cleanup is delayed
 
 # - Standby Servers -


### PR DESCRIPTION
### Description of your patch
Custom setting updated 

### Recommended Release Notes
Fixed Postgres setting rename on PG version >=13

### Estimated risk
High

### Components involved
Clients who use Postgresql version > 11

### Dependencies
ey-postgresql

### Description of testing done

**Case1:**
Create v7 environment with Postgresql version selected from dropdown. 
Boot Environment. 
Check if postgres running. 
Check for version running. 
Check file   /db/postgresql/14/data/postgresql.conf |grep wal , it should have `wal_keep_segments=128`

**Case2:** 
Create v7 environment with Postgresql
Boot Environment after adding environmnet variable `EY_POSTGRES_VERSION` > = 13
Check if postgres running. 
Check for version running. 
Check file   /db/postgresql/14/data/postgresql.conf |grep wal , it should have `wal_keep_size = 128`

### QA Instructions
**Case1:**
Create v7 environment with Postgresql version selected from dropdown. 
Boot Environment. 
Check if postgres running. 
Check for version running. 
Check file   /db/postgresql/14/data/postgresql.conf |grep wal , it should have `wal_keep_segments=128`

**Case2:** 
Create v7 environment with Postgresql
Boot Environment after adding environmnet variable `EY_POSTGRES_VERSION` > = 13
Check if postgres running. 
Check for version running. 
Check file   /db/postgresql/14/data/postgresql.conf |grep wal , it should have `wal_keep_size = 128`