### PR TITLE
[FBZ-10499] Migrate eydr Recipe to v7

### DIFF
--- a/custom-cookbooks/eydr/README.md
+++ b/custom-cookbooks/eydr/README.md
@@ -1,0 +1,5 @@
+#EY DR
+
+This example contains a complete cookbooks/ that you can use on the stable-v7 stack.
+
+See https://github.com/engineyard/ey-cookbooks-stable-v7/tree/next-release/custom-cookbooks/eydr/cookbooks/eydr for complete instructions.

--- a/custom-cookbooks/eydr/cookbooks/ey-custom/metadata.rb
+++ b/custom-cookbooks/eydr/cookbooks/ey-custom/metadata.rb
@@ -1,0 +1,4 @@
+name "ey-custom"
+version "1.0.0"
+
+depends "eydr"

--- a/custom-cookbooks/eydr/cookbooks/ey-custom/recipes/after-main.rb
+++ b/custom-cookbooks/eydr/cookbooks/ey-custom/recipes/after-main.rb
@@ -1,0 +1,1 @@
+include_recipe "eydr"

--- a/custom-cookbooks/eydr/cookbooks/eydr/README.md
+++ b/custom-cookbooks/eydr/cookbooks/eydr/README.md
@@ -18,21 +18,21 @@ Configure
 1) Configure the following attributes in the dr_replication cookbook:
 
 ```
-default[:dr_replication] = {
-  :<framework_env> => {
-    :master => {
-      :public_hostname => "" # The public hostname of the master database
+default['dr_replication'] = {
+  <framework_env>: {
+    master: {
+      public_hostname: "" # The public hostname of the master database
     },
-    :initiate => {
-      :public_hostname => "" # MySQL ONLY - The public hostname of the database you want to sync the data from (can be the slave or master)
+    initiate: {
+      public_hostname: "" # MySQL ONLY - The public hostname of the database you want to sync the data from (can be the slave or master)
     },
-    :slave => {
-      :public_hostname => "" # The public hostname of the disaster recovery database
+    slave: {
+      public_hostname: "" # The public hostname of the disaster recovery database
     }
   }
 
-  default[:establish_replication] = false # Set to true to establish replication during Chef run
-  default[:failover] = false # Set to true to failover to D/R environment during Chef run
+  default['establish_replication'] = false # Set to true to establish replication during Chef run
+  default['failover'] = false # Set to true to failover to D/R environment during Chef run
 ```
 
 2) Upload and apply Chef cookbooks:
@@ -47,8 +47,8 @@ Steps to Failover
 1) Set the failover attribute to true and establish_replication to false:
 
 ```
-default[:establish_replication] = false
-default[:failover] = true
+default['establish_replication'] = false
+default['failover'] = true
 ```
 
 2) Upload and apply

--- a/custom-cookbooks/eydr/cookbooks/eydr/README.md
+++ b/custom-cookbooks/eydr/cookbooks/eydr/README.md
@@ -31,8 +31,8 @@ default['dr_replication'] = {
     }
   }
 
-  default['establish_replication'] = false # Set to true to establish replication during Chef run
-  default['failover'] = false # Set to true to failover to D/R environment during Chef run
+  default["establish_replication"] = false # Set to true to establish replication during Chef run
+  default["failover"] = false # Set to true to failover to D/R environment during Chef run
 ```
 
 2) Upload and apply Chef cookbooks:
@@ -47,8 +47,8 @@ Steps to Failover
 1) Set the failover attribute to true and establish_replication to false:
 
 ```
-default['establish_replication'] = false
-default['failover'] = true
+default["establish_replication"] = false
+default["failover"] = true
 ```
 
 2) Upload and apply

--- a/custom-cookbooks/eydr/cookbooks/eydr/README.md
+++ b/custom-cookbooks/eydr/cookbooks/eydr/README.md
@@ -1,0 +1,59 @@
+EY Cloud Disaster Recovery
+==========================
+
+Pre-Requisites
+-------------------
+1) In another region, configure an environment identical to the live environment and boot instances.
+
+2) Generate SSH keys to be used by the SSH tunnel (do not use a passphrase): `ssh-keygen -t rsa -b 2048 -f ./eydr_key`
+
+3) An Engine Yard Support Engineer must add the SSH keys generated to our metadata.  The names should be eydr_private_key and eydr_public_key and they should be added at the account level.  The carriage returns in the private key must be replaced with \n when adding to the web interface.
+
+4) Add the SSH key generated in step 2 to the dashboard (both environments) so that it is added to the deploy user's authorized_keys file:  [Add An SSH Key](https://support.cloud.engineyard.com/hc/en-us/articles/205407248-Add-an-SSH-Key)
+
+5) An Engine Yard Support Engineer must update the slave environment password to match the master environment password.  This must be done via the awsm console and can not be done by customers. [Internal Reference: DOC-2184](https://engineyard.jiveon.com/docs/DOC-2184)
+
+Configure
+---------
+1) Configure the following attributes in the dr_replication cookbook:
+
+```
+default[:dr_replication] = {
+  :<framework_env> => {
+    :master => {
+      :public_hostname => "" # The public hostname of the master database
+    },
+    :initiate => {
+      :public_hostname => "" # MySQL ONLY - The public hostname of the database you want to sync the data from (can be the slave or master)
+    },
+    :slave => {
+      :public_hostname => "" # The public hostname of the disaster recovery database
+    }
+  }
+
+  default[:establish_replication] = false # Set to true to establish replication during Chef run
+  default[:failover] = false # Set to true to failover to D/R environment during Chef run
+```
+
+2) Upload and apply Chef cookbooks:
+
+```
+ey recipes upload --apply -e <master_environment_name>
+ey recipes upload --apply -e <slave_environment_name>
+```
+
+Steps to Failover
+-----------------
+1) Set the failover attribute to true and establish_replication to false:
+
+```
+default[:establish_replication] = false
+default[:failover] = true
+```
+
+2) Upload and apply
+
+Notes
+-----
+* Deployments must be done on both environments to keep the application code up to date
+* Custom recipes must be applied on both environments to keep configurations up to date

--- a/custom-cookbooks/eydr/cookbooks/eydr/attributes/dns.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/attributes/dns.rb
@@ -1,0 +1,8 @@
+default['dns_failover'] = {
+  provider: 'dynect',
+  customer: '<UPDATE>',
+  username: '<UPDATE>',
+  password: '<UPDATE>',
+  zone: '<UPDATE>',
+  enabled: false,
+}

--- a/custom-cookbooks/eydr/cookbooks/eydr/attributes/dns.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/attributes/dns.rb
@@ -1,8 +1,8 @@
-default['dns_failover'] = {
-  provider: 'dynect',
-  customer: '<UPDATE>',
-  username: '<UPDATE>',
-  password: '<UPDATE>',
-  zone: '<UPDATE>',
+default["dns_failover"] = {
+  provider: "dynect",
+  customer: "<UPDATE>",
+  username: "<UPDATE>",
+  password: "<UPDATE>",
+  zone: "<UPDATE>",
   enabled: false,
 }

--- a/custom-cookbooks/eydr/cookbooks/eydr/attributes/replication.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/attributes/replication.rb
@@ -20,4 +20,4 @@ default["dr_replication"] = {
 default["establish_replication"] = false
 
 # Set to true to failover to D/R environment during Chef run
-default["failover"] = false
+default['failover'] = false

--- a/custom-cookbooks/eydr/cookbooks/eydr/attributes/replication.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/attributes/replication.rb
@@ -20,4 +20,4 @@ default["dr_replication"] = {
 default["establish_replication"] = false
 
 # Set to true to failover to D/R environment during Chef run
-default['failover'] = false
+default["failover"] = false

--- a/custom-cookbooks/eydr/cookbooks/eydr/attributes/replication.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/attributes/replication.rb
@@ -1,0 +1,24 @@
+default['dr_replication'] = {
+  production: {
+    master: {
+      public_hostname: '',
+    },
+    # MySQL Only
+    initiate: {
+      public_hostname: '',
+    },
+    slave: {
+      public_hostname: '',
+    },
+  },
+  # The following 2 URLs are required for MySQL replication
+#  xtrabackup_download_url: 'http://www.percona.com/redir/downloads/XtraBackup/XtraBackup-2.2.6/binary/tarball/percona-xtrabackup-2.2.6-5042-Linux-x86_64.tar.gz',
+  xtrabackup_download_url: 'https://downloads.percona.com/downloads/Percona-XtraBackup-LATEST/Percona-XtraBackup-8.0.29-22/binary/debian/focal/x86_64/Percona-XtraBackup-8.0.29-22-rc31e7ddcce3-focal-x86_64-bundle.tar',
+  qpress_download_url: 'http://www.quicklz.com/qpress-11-linux-x64.tar',
+}
+
+# Set to true to establish replication during Chef run
+default['establish_replication'] = false
+
+# Set to true to failover to D/R environment during Chef run
+default['failover'] = false

--- a/custom-cookbooks/eydr/cookbooks/eydr/attributes/replication.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/attributes/replication.rb
@@ -1,23 +1,23 @@
-default['dr_replication'] = {
+default["dr_replication"] = {
   production: {
     master: {
-      public_hostname: '',
+      public_hostname: "",
     },
     # MySQL Only
     initiate: {
-      public_hostname: '',
+      public_hostname: "",
     },
     slave: {
-      public_hostname: '',
+      public_hostname: "",
     },
   },
   # The following 2 URLs are required for MySQL replication
-  xtrabackup_download_url: 'https://downloads.percona.com/downloads/Percona-XtraBackup-LATEST/Percona-XtraBackup-8.0.29-22/binary/debian/focal/x86_64/Percona-XtraBackup-8.0.29-22-rc31e7ddcce3-focal-x86_64-bundle.tar',
-  qpress_download_url: 'http://www.quicklz.com/qpress-11-linux-x64.tar',
+  xtrabackup_download_url: "https://downloads.percona.com/downloads/Percona-XtraBackup-LATEST/Percona-XtraBackup-8.0.29-22/binary/debian/focal/x86_64/Percona-XtraBackup-8.0.29-22-rc31e7ddcce3-focal-x86_64-bundle.tar",
+  qpress_download_url: "http://www.quicklz.com/qpress-11-linux-x64.tar",
 }
 
 # Set to true to establish replication during Chef run
-default['establish_replication'] = false
+default["establish_replication"] = false
 
 # Set to true to failover to D/R environment during Chef run
-default['failover'] = false
+default["failover"] = false

--- a/custom-cookbooks/eydr/cookbooks/eydr/attributes/replication.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/attributes/replication.rb
@@ -12,7 +12,6 @@ default['dr_replication'] = {
     },
   },
   # The following 2 URLs are required for MySQL replication
-#  xtrabackup_download_url: 'http://www.percona.com/redir/downloads/XtraBackup/XtraBackup-2.2.6/binary/tarball/percona-xtrabackup-2.2.6-5042-Linux-x86_64.tar.gz',
   xtrabackup_download_url: 'https://downloads.percona.com/downloads/Percona-XtraBackup-LATEST/Percona-XtraBackup-8.0.29-22/binary/debian/focal/x86_64/Percona-XtraBackup-8.0.29-22-rc31e7ddcce3-focal-x86_64-bundle.tar',
   qpress_download_url: 'http://www.quicklz.com/qpress-11-linux-x64.tar',
 }

--- a/custom-cookbooks/eydr/cookbooks/eydr/attributes/version.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/attributes/version.rb
@@ -1,24 +1,20 @@
-case node['dna']['engineyard']['environment']['db_stack_name']
-when 'mysql5_7'
-  default['mysql']['latest_version'] = '5.7.37'
-  default['mysql']['virtual'] = '5.7'
-  default['mysql']['short_version'] = '5.7'
-  default['mysql']['datadir'] = "/db/mysql/#{node['mysql']['short_version']}/data/"
-when 'mysql8_0'
-  default['mysql']['latest_version'] = '8.0.28'
-  default['mysql']['virtual'] = '8.0'
-  default['mysql']['short_version'] = '8.0'
-  default['mysql']['datadir'] = "/db/mysql/#{node['mysql']['short_version']}/data/"
-when 'postgres9_5'
-  default['postgresql']['latest_version'] = '9.5.25'
+case node["dna"]["engineyard"]["environment"]["db_stack_name"]
+when "mysql5_7"
+  default["mysql"]["latest_version"] = "5.7.37"
+  default["mysql"]["virtual"] = "5.7"
+  default["mysql"]["short_version"] = "5.7"
+  default["mysql"]["datadir"] = "/db/mysql/#{node['mysql']['short_version']}/data/"
+when "mysql8_0"
+  default["mysql"]["latest_version"] = "8.0.28"
+  default["mysql"]["virtual"] = "8.0"
+  default["mysql"]["short_version"] = "8.0"
+  default["mysql"]["datadir"] = "/db/mysql/#{node['mysql']['short_version']}/data/"
+when "postgres9_5"
+  default["postgresql"]["latest_version"] = "9.5.25"
   default["postgresql"]["short_version"] = "9.5"
-  default['postgresql']['datadir'] = "/db/postgresql/#{node['postgresql']['short_version']}/data/"
-when 'postgres9_6'
-  default['postgresql']['latest_version'] = '9.6.24'
-  default['postgresql']['short_version'] = '9.6'
-  default['postgresql']['datadir'] = "/db/postgresql/#{node['postgresql']['short_version']}/data/"
-when 'postgres10'
-  default['postgresql']['latest_version'] = '10.20'
-  default['postgresql']['short_version'] = '10'
-  default['postgresql']['datadir'] = "/db/postgresql/#{node['postgresql']['short_version']}/data/"
+  default["postgresql"]["datadir"] = "/db/postgresql/#{node['postgresql']['short_version']}/data/"
+when "postgres9_6"
+  default["postgresql"]["latest_version"] = "9.6.24"
+  default["postgresql"]["short_version"] = "9.6"
+  default["postgresql"]["datadir"] = "/db/postgresql/#{node['postgresql']['short_version']}/data/"
 end

--- a/custom-cookbooks/eydr/cookbooks/eydr/attributes/version.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/attributes/version.rb
@@ -1,4 +1,4 @@
-case node.engineyard.environment['db_stack_name']
+case node['dna']['engineyard']['environment']['db_stack_name']
 when 'mysql5_7'
   default['mysql']['latest_version'] = '5.7.37'
   default['mysql']['virtual'] = '5.7'
@@ -20,9 +20,5 @@ when 'postgres9_6'
 when 'postgres10'
   default['postgresql']['latest_version'] = '10.20'
   default['postgresql']['short_version'] = '10'
-  default['postgresql']['datadir'] = "/db/postgresql/#{node['postgresql']['short_version']}/data/"
-when 'postgres11'
-  default['postgresql']['latest_version'] = '11.16'
-  default['postgresql']['short_version'] = '11'
   default['postgresql']['datadir'] = "/db/postgresql/#{node['postgresql']['short_version']}/data/"
 end

--- a/custom-cookbooks/eydr/cookbooks/eydr/attributes/version.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/attributes/version.rb
@@ -1,0 +1,28 @@
+case node.engineyard.environment['db_stack_name']
+when 'mysql5_7'
+  default['mysql']['latest_version'] = '5.7.37'
+  default['mysql']['virtual'] = '5.7'
+  default['mysql']['short_version'] = '5.7'
+  default['mysql']['datadir'] = "/db/mysql/#{node['mysql']['short_version']}/data/"
+when 'mysql8_0'
+  default['mysql']['latest_version'] = '8.0.28'
+  default['mysql']['virtual'] = '8.0'
+  default['mysql']['short_version'] = '8.0'
+  default['mysql']['datadir'] = "/db/mysql/#{node['mysql']['short_version']}/data/"
+when 'postgres9_5'
+  default['postgresql']['latest_version'] = '9.5.25'
+  default["postgresql"]["short_version"] = "9.5"
+  default['postgresql']['datadir'] = "/db/postgresql/#{node['postgresql']['short_version']}/data/"
+when 'postgres9_6'
+  default['postgresql']['latest_version'] = '9.6.24'
+  default['postgresql']['short_version'] = '9.6'
+  default['postgresql']['datadir'] = "/db/postgresql/#{node['postgresql']['short_version']}/data/"
+when 'postgres10'
+  default['postgresql']['latest_version'] = '10.20'
+  default['postgresql']['short_version'] = '10'
+  default['postgresql']['datadir'] = "/db/postgresql/#{node['postgresql']['short_version']}/data/"
+when 'postgres11'
+  default['postgresql']['latest_version'] = '11.16'
+  default['postgresql']['short_version'] = '11'
+  default['postgresql']['datadir'] = "/db/postgresql/#{node['postgresql']['short_version']}/data/"
+end

--- a/custom-cookbooks/eydr/cookbooks/eydr/files/default/logbin.cnf
+++ b/custom-cookbooks/eydr/cookbooks/eydr/files/default/logbin.cnf
@@ -1,0 +1,3 @@
+[mysqld]
+log-bin
+server-id                                       = 1

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/default.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/default.rb
@@ -3,30 +3,27 @@
 # Recipe:: default
 #
 
-Chef::Log.info("DB OR SOLO #{node["dna"]["instance_role"][/^(db|solo)/]}")
-Chef::Log.info("REPLICATION = #{node.engineyard.environment['db_stack_name'].split(/[0-9]/).first}")
-
-if node["dna"]["instance_role"][/^(db|solo)/] && node['ec2']['public_hostname'] == node['dr_replication'][node['dna']['environment']['framework_env']]['master']['public_hostname']
+if ['db_master', 'db_slave', 'solo'].include?(node['dna']['instance_role']) && node['ec2']['public_hostname'] == node['dr_replication'][node['dna']['environment']['framework_env']]['master']['public_hostname']
   Chef::Log.info 'Configuring master for replication'
   include_recipe 'eydr::keys'
-  include_recipe "eydr::#{node.engineyard.environment['db_stack_name'].split(/[0-9]/).first}_master_configuration"
+  include_recipe "eydr::#{node['dna']['engineyard']['environment']['db_stack_name'].split(/[0-9]/).first}_master_configuration"
 end
 
-if node["dna"]["instance_role"][/^(db|solo)/] && node['ec2']['public_hostname'] == node['dr_replication'][node['dna']['environment']['framework_env']]['initiate']['public_hostname']
+if ['db_master', 'db_slave', 'solo'].include?(node['dna']['instance_role']) && node['ec2']['public_hostname'] == node['dr_replication'][node['dna']['environment']['framework_env']]['initiate']['public_hostname']
   Chef::Log.info 'Configuring keys and installing Xtrabackup for replication'
   include_recipe 'eydr::keys'
-  include_recipe "eydr::#{node.engineyard.environment['db_stack_name'].split(/[0-9]/).first}_master_configuration"
+  include_recipe "eydr::#{node['dna']['engineyard']['environment']['db_stack_name'].split(/[0-9]/).first}_master_configuration"
 end
 
-if node["dna"]["instance_role"][/^(db|solo)/] && node['ec2']['public_hostname'] == node['dr_replication'][node['dna']['environment']['framework_env']]['slave']['public_hostname']
+if ['db_master', 'db_slave', 'solo'].include?(node['dna']['instance_role']) && node['ec2']['public_hostname'] == node['dr_replication'][node['dna']['environment']['framework_env']]['slave']['public_hostname']
   Chef::Log.info 'Configuring slave for replication'
   include_recipe 'eydr::keys'
   include_recipe 'eydr::ssh_tunnel'
-  include_recipe "eydr::#{node.engineyard.environment['db_stack_name'].split(/[0-9]/).first}_replication"
+  include_recipe "eydr::#{node['dna']['engineyard']['environment']['db_stack_name'].split(/[0-9]/).first}_replication"
 
   if node['failover']
     Chef::Log.info 'Failing over initiated...'
-    include_recipe "eydr::#{node.engineyard.environment['db_stack_name'].split(/[0-9]/).first}_monitoring"
+    include_recipe "eydr::#{node['dna']['engineyard']['environment']['db_stack_name'].split(/[0-9]/).first}_monitoring"
     Chef::Log.info 'Current database master has been promoted to slave'
   end
 end
@@ -34,7 +31,7 @@ end
 # Failover section
 if node['failover'] && node['ec2']['public_hostname'] == node['dr_replication'][node['dna']['environment']['framework_env']]['slave']['public_hostname']
   if ['solo', 'db_master'].include?(node['dna']['instance_role'])
-    include_recipe "eydr::#{node.engineyard.environment['db_stack_name'].split(/[0-9]/).first}_failover"
+    include_recipe "eydr::#{node['dna']['engineyard']['environment']['db_stack_name'].split(/[0-9]/).first}_failover"
   end
 
   if node['dns_failover']['enabled'] && ['app_master'].include?(node['dna']['instance_role'])

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/default.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/default.rb
@@ -3,38 +3,38 @@
 # Recipe:: default
 #
 
-if ['db_master', 'db_slave', 'solo'].include?(node['dna']['instance_role']) && node['ec2']['public_hostname'] == node['dr_replication'][node['dna']['environment']['framework_env']]['master']['public_hostname']
-  Chef::Log.info 'Configuring master for replication'
-  include_recipe 'eydr::keys'
+if ["db_master", "db_slave", "solo"].include?(node["dna"]["instance_role"]) && node["ec2"]["public_hostname"] == node["dr_replication"][node["dna"]["environment"]["framework_env"]]["master"]["public_hostname"]
+  Chef::Log.info "Configuring master for replication"
+  include_recipe "eydr::keys"
   include_recipe "eydr::#{node['dna']['engineyard']['environment']['db_stack_name'].split(/[0-9]/).first}_master_configuration"
 end
 
-if ['db_master', 'db_slave', 'solo'].include?(node['dna']['instance_role']) && node['ec2']['public_hostname'] == node['dr_replication'][node['dna']['environment']['framework_env']]['initiate']['public_hostname']
-  Chef::Log.info 'Configuring keys and installing Xtrabackup for replication'
-  include_recipe 'eydr::keys'
+if ["db_master", "db_slave", "solo"].include?(node["dna"]["instance_role"]) && node["ec2"]["public_hostname"] == node["dr_replication"][node["dna"]["environment"]["framework_env"]]["initiate"]["public_hostname"]
+  Chef::Log.info "Configuring keys and installing Xtrabackup for replication"
+  include_recipe "eydr::keys"
   include_recipe "eydr::#{node['dna']['engineyard']['environment']['db_stack_name'].split(/[0-9]/).first}_master_configuration"
 end
 
-if ['db_master', 'db_slave', 'solo'].include?(node['dna']['instance_role']) && node['ec2']['public_hostname'] == node['dr_replication'][node['dna']['environment']['framework_env']]['slave']['public_hostname']
-  Chef::Log.info 'Configuring slave for replication'
-  include_recipe 'eydr::keys'
-  include_recipe 'eydr::ssh_tunnel'
+if ["db_master", "db_slave", "solo"].include?(node["dna"]["instance_role"]) && node["ec2"]["public_hostname"] == node["dr_replication"][node["dna"]["environment"]["framework_env"]]["slave"]["public_hostname"]
+  Chef::Log.info "Configuring slave for replication"
+  include_recipe "eydr::keys"
+  include_recipe "eydr::ssh_tunnel"
   include_recipe "eydr::#{node['dna']['engineyard']['environment']['db_stack_name'].split(/[0-9]/).first}_replication"
 
-  if node['failover']
-    Chef::Log.info 'Failing over initiated...'
+  if node["failover"]
+    Chef::Log.info "Failing over initiated..."
     include_recipe "eydr::#{node['dna']['engineyard']['environment']['db_stack_name'].split(/[0-9]/).first}_monitoring"
-    Chef::Log.info 'Current database master has been promoted to slave'
+    Chef::Log.info "Current database master has been promoted to slave"
   end
 end
 
 # Failover section
-if node['failover'] && node['ec2']['public_hostname'] == node['dr_replication'][node['dna']['environment']['framework_env']]['slave']['public_hostname']
-  if ['solo', 'db_master'].include?(node['dna']['instance_role'])
+if node["failover"] && node["ec2"]["public_hostname"] == node["dr_replication"][node["dna"]["environment"]["framework_env"]]["slave"]["public_hostname"]
+  if ["solo", "db_master"].include?(node["dna"]["instance_role"])
     include_recipe "eydr::#{node['dna']['engineyard']['environment']['db_stack_name'].split(/[0-9]/).first}_failover"
   end
 
-  if node['dns_failover']['enabled'] && ['app_master'].include?(node['dna']['instance_role'])
-    include_recipe 'eydr::dns_failover'
+  if node["dns_failover"]["enabled"] && ["app_master"].include?(node["dna"]["instance_role"])
+    include_recipe "eydr::dns_failover"
   end
 end

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/default.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/default.rb
@@ -1,0 +1,43 @@
+#
+# Cookbook:: dr_replication
+# Recipe:: default
+#
+
+Chef::Log.info("DB OR SOLO #{node["dna"]["instance_role"][/^(db|solo)/]}")
+Chef::Log.info("REPLICATION = #{node.engineyard.environment['db_stack_name'].split(/[0-9]/).first}")
+
+if node["dna"]["instance_role"][/^(db|solo)/] && node['ec2']['public_hostname'] == node['dr_replication'][node['dna']['environment']['framework_env']]['master']['public_hostname']
+  Chef::Log.info 'Configuring master for replication'
+  include_recipe 'eydr::keys'
+  include_recipe "eydr::#{node.engineyard.environment['db_stack_name'].split(/[0-9]/).first}_master_configuration"
+end
+
+if node["dna"]["instance_role"][/^(db|solo)/] && node['ec2']['public_hostname'] == node['dr_replication'][node['dna']['environment']['framework_env']]['initiate']['public_hostname']
+  Chef::Log.info 'Configuring keys and installing Xtrabackup for replication'
+  include_recipe 'eydr::keys'
+  include_recipe "eydr::#{node.engineyard.environment['db_stack_name'].split(/[0-9]/).first}_master_configuration"
+end
+
+if node["dna"]["instance_role"][/^(db|solo)/] && node['ec2']['public_hostname'] == node['dr_replication'][node['dna']['environment']['framework_env']]['slave']['public_hostname']
+  Chef::Log.info 'Configuring slave for replication'
+  include_recipe 'eydr::keys'
+  include_recipe 'eydr::ssh_tunnel'
+  include_recipe "eydr::#{node.engineyard.environment['db_stack_name'].split(/[0-9]/).first}_replication"
+
+  if node['failover']
+    Chef::Log.info 'Failing over initiated...'
+    include_recipe "eydr::#{node.engineyard.environment['db_stack_name'].split(/[0-9]/).first}_monitoring"
+    Chef::Log.info 'Current database master has been promoted to slave'
+  end
+end
+
+# Failover section
+if node['failover'] && node['ec2']['public_hostname'] == node['dr_replication'][node['dna']['environment']['framework_env']]['slave']['public_hostname']
+  if ['solo', 'db_master'].include?(node['dna']['instance_role'])
+    include_recipe "eydr::#{node.engineyard.environment['db_stack_name'].split(/[0-9]/).first}_failover"
+  end
+
+  if node['dns_failover']['enabled'] && ['app_master'].include?(node['dna']['instance_role'])
+    include_recipe 'eydr::dns_failover'
+  end
+end

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/dns_failover.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/dns_failover.rb
@@ -1,0 +1,6 @@
+#
+# Cookbook:: dns_failover
+# Recipe:: default
+#
+
+include_recipe "eydr::#{node['dns_failover']['provider']}"

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/dynect.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/dynect.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook:: dns_failover
+# Recipe:: dynect
+#
+
+template '/engineyard/bin/dynect_update.rb' do
+  source 'dynect_update.rb.erb'
+  owner 'root'
+  group 'root'
+  mode '0755'
+  backup 0
+  variables({
+    provider: node['dns_failover']['provider'],
+    customer: node['dns_failover']['customer'],
+    username: node['dns_failover']['username'],
+    password: node['dns_failover']['password'],
+    zone: node['dns_failover']['zone'],
+    records: node['dns_failover']['records'],
+  })
+end
+
+bash 'dynect-update' do
+  code '/engineyard/bin/dynect_update.rb'
+end

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/dynect.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/dynect.rb
@@ -3,22 +3,22 @@
 # Recipe:: dynect
 #
 
-template '/engineyard/bin/dynect_update.rb' do
-  source 'dynect_update.rb.erb'
-  owner 'root'
-  group 'root'
-  mode '0755'
+template "/engineyard/bin/dynect_update.rb" do
+  source "dynect_update.rb.erb"
+  owner "root"
+  group "root"
+  mode "0755"
   backup 0
   variables({
-    provider: node['dns_failover']['provider'],
-    customer: node['dns_failover']['customer'],
-    username: node['dns_failover']['username'],
-    password: node['dns_failover']['password'],
-    zone: node['dns_failover']['zone'],
-    records: node['dns_failover']['records'],
+    provider: node["dns_failover"]["provider"],
+    customer: node["dns_failover"]["customer"],
+    username: node["dns_failover"]["username"],
+    password: node["dns_failover"]["password"],
+    zone: node["dns_failover"]["zone"],
+    records: node["dns_failover"]["records"],
   })
 end
 
-bash 'dynect-update' do
-  code '/engineyard/bin/dynect_update.rb'
+bash "dynect-update" do
+  code "/engineyard/bin/dynect_update.rb"
 end

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/install_xtrabackup.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/install_xtrabackup.rb
@@ -4,53 +4,53 @@
 #
 
 # Download xtrabackup from URL specificed in attributes
-bash 'download-xtrabackup' do
-  user node['owner_name']
+bash "download-xtrabackup" do
+  user node["owner_name"]
   code "cd /home/#{node['owner_name']}/ && wget #{node['dr_replication']['xtrabackup_download_url']}"
   not_if { ::File.exist? "/home/#{node['owner_name']}/#{node['dr_replication']['xtrabackup_download_url'].split('/').last}" }
 end
 
 # Untar xtrabackup
-bash 'untar-xtrabackup' do
-  user node['owner_name']
+bash "untar-xtrabackup" do
+  user node["owner_name"]
   code "cd /home/#{node['owner_name']}/ && tar -xvf #{node['dr_replication']['xtrabackup_download_url'].split('/').last}"
 end
 
 # Copy xtrabackup into /usr/bin so that it's in the PATH
-bash 'copy-xtrabackup' do
-  user 'root'
+bash "copy-xtrabackup" do
+  user "root"
   code "yes | cp -ruf /home/#{node['owner_name']}/#{node['dr_replication']['xtrabackup_download_url'].split('/').last.split('-')[0..2].join('-')}*/bin/* /usr/bin/"
 end
 
 # Ensure proper ownership
-bash 'chown-xtrabackup' do
-  user 'root'
-  cwd '/usr/bin/'
+bash "chown-xtrabackup" do
+  user "root"
+  cwd "/usr/bin/"
   code "chown #{node['owner_name']}:#{node['owner_name']} innobackupex xbcrypt xbstream xtrabackup*"
 end
 
 # Install libaio (required for xtrabackup)
-package 'dev-libs/libaio' do
+package "dev-libs/libaio" do
   action :install
 end
 
 # Download qpress from the URL specified in attributes (used for compression)
-bash 'download-qpress' do
-  user node['owner_name']
+bash "download-qpress" do
+  user node["owner_name"]
   cwd "/home/#{node['owner_name']}/"
   code "wget #{node['dr_replication']['qpress_download_url']}"
   not_if { ::File.exist? "/home/#{node['owner_name']}/#{node['dr_replication']['qpress_download_url'].split('/').last}" }
 end
 
 # Untar qpress
-bash 'copy-qpress' do
-  user node['owner_name']
+bash "copy-qpress" do
+  user node["owner_name"]
   cwd "/home/#{node['owner_name']}/"
   code "tar xvf #{node['dr_replication']['qpress_download_url'].split('/').last}"
 end
 
 # Copy apress into /usr/bin so that it's in the PATH
-bash 'copy-qpress' do
-  user 'root'
+bash "copy-qpress" do
+  user "root"
   code "yes | cp -ruf /home/#{node['owner_name']}/qpress /usr/bin/"
 end

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/install_xtrabackup.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/install_xtrabackup.rb
@@ -1,0 +1,56 @@
+#
+# Cookbook:: dr_replication
+# Recipe:: install_xtrabackup
+#
+
+# Download xtrabackup from URL specificed in attributes
+bash 'download-xtrabackup' do
+  user node['owner_name']
+  code "cd /home/#{node['owner_name']}/ && wget #{node['dr_replication']['xtrabackup_download_url']}"
+  not_if { ::File.exist? "/home/#{node['owner_name']}/#{node['dr_replication']['xtrabackup_download_url'].split('/').last}" }
+end
+
+# Untar xtrabackup
+bash 'untar-xtrabackup' do
+  user node['owner_name']
+  code "cd /home/#{node['owner_name']}/ && tar -xvf #{node['dr_replication']['xtrabackup_download_url'].split('/').last}"
+end
+
+# Copy xtrabackup into /usr/bin so that it's in the PATH
+bash 'copy-xtrabackup' do
+  user 'root'
+  code "yes | cp -ruf /home/#{node['owner_name']}/#{node['dr_replication']['xtrabackup_download_url'].split('/').last.split('-')[0..2].join('-')}*/bin/* /usr/bin/"
+end
+
+# Ensure proper ownership
+bash 'chown-xtrabackup' do
+  user 'root'
+  cwd '/usr/bin/'
+  code "chown #{node['owner_name']}:#{node['owner_name']} innobackupex xbcrypt xbstream xtrabackup*"
+end
+
+# Install libaio (required for xtrabackup)
+package 'dev-libs/libaio' do
+  action :install
+end
+
+# Download qpress from the URL specified in attributes (used for compression)
+bash 'download-qpress' do
+  user node['owner_name']
+  cwd "/home/#{node['owner_name']}/"
+  code "wget #{node['dr_replication']['qpress_download_url']}"
+  not_if { ::File.exist? "/home/#{node['owner_name']}/#{node['dr_replication']['qpress_download_url'].split('/').last}" }
+end
+
+# Untar qpress
+bash 'copy-qpress' do
+  user node['owner_name']
+  cwd "/home/#{node['owner_name']}/"
+  code "tar xvf #{node['dr_replication']['qpress_download_url'].split('/').last}"
+end
+
+# Copy apress into /usr/bin so that it's in the PATH
+bash 'copy-qpress' do
+  user 'root'
+  code "yes | cp -ruf /home/#{node['owner_name']}/qpress /usr/bin/"
+end

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/keys.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/keys.rb
@@ -1,0 +1,60 @@
+#
+# Cookbook:: dr_replication
+# Recipe:: keys
+#
+
+private_key = metadata_any_get_with_default('eydr_private_key', '<ADD TO METADATA>')
+public_key = metadata_any_get_with_default('eydr_public_key', '<ADD TO METADATA>')
+
+file "/home/#{node['owner_name']}/.ssh/eydr_key" do
+  owner node['owner_name']
+  group node['owner_name']
+  mode '0600'
+  action :create
+  content private_key
+end
+
+file "/home/#{node['owner_name']}/.ssh/eydr_key.pub" do
+  owner node['owner_name']
+  group node['owner_name']
+  mode '0600'
+  action :create
+  content public_key
+end
+
+if node['dna']['engineyard']['environment']['db_stack_name'] =~ /postgres/
+  directory '/var/lib/postgresql/.ssh/' do
+    owner 'postgres'
+    group 'postgres'
+    mode '0755'
+    recursive true
+    action :create
+  end
+
+  bash 'touch-postgresql-authorized-keys' do
+    user 'postgres'
+    code 'touch /var/lib/postgresql/.ssh/authorized_keys'
+    not_if { ::File.exist?('/var/lib/postgresql/.ssh/authorized_keys') }
+  end
+
+  file '/var/lib/postgresql/.ssh/id_rsa' do
+    owner 'postgres'
+    group 'postgres'
+    mode '0700'
+    backup 0
+    content private_key
+  end
+
+  file '/var/lib/postgresql/.ssh/id_rsa.pub' do
+    owner 'postgres'
+    group 'postgres'
+    mode '0700'
+    backup 0
+    content public_key
+  end
+
+  bash 'configure-authorized-keys-for-postgres' do
+    code 'cat /var/lib/postgresql/.ssh/id_rsa.pub >> /var/lib/postgresql/.ssh/authorized_keys'
+    not_if 'grep "`cat /var/lib/postgresql/.ssh/id_rsa.pub`" /var/lib/postgresql/.ssh/authorized_keys'
+  end
+end

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/keys.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/keys.rb
@@ -3,58 +3,58 @@
 # Recipe:: keys
 #
 
-private_key = metadata_any_get_with_default('eydr_private_key', '<ADD TO METADATA>')
-public_key = metadata_any_get_with_default('eydr_public_key', '<ADD TO METADATA>')
+private_key = metadata_any_get_with_default("eydr_private_key", "<ADD TO METADATA>")
+public_key = metadata_any_get_with_default("eydr_public_key", "<ADD TO METADATA>")
 
 file "/home/#{node['owner_name']}/.ssh/eydr_key" do
-  owner node['owner_name']
-  group node['owner_name']
-  mode '0600'
+  owner node["owner_name"]
+  group node["owner_name"]
+  mode "0600"
   action :create
   content private_key
 end
 
 file "/home/#{node['owner_name']}/.ssh/eydr_key.pub" do
-  owner node['owner_name']
-  group node['owner_name']
-  mode '0600'
+  owner node["owner_name"]
+  group node["owner_name"]
+  mode "0600"
   action :create
   content public_key
 end
 
-if node['dna']['engineyard']['environment']['db_stack_name'] =~ /postgres/
-  directory '/var/lib/postgresql/.ssh/' do
-    owner 'postgres'
-    group 'postgres'
-    mode '0755'
+if node["dna"]["engineyard"]["environment"]["db_stack_name"] =~ /postgres/
+  directory "/var/lib/postgresql/.ssh/" do
+    owner "postgres"
+    group "postgres"
+    mode "0755"
     recursive true
     action :create
   end
 
-  bash 'touch-postgresql-authorized-keys' do
-    user 'postgres'
-    code 'touch /var/lib/postgresql/.ssh/authorized_keys'
-    not_if { ::File.exist?('/var/lib/postgresql/.ssh/authorized_keys') }
+  bash "touch-postgresql-authorized-keys" do
+    user "postgres"
+    code "touch /var/lib/postgresql/.ssh/authorized_keys"
+    not_if { ::File.exist?("/var/lib/postgresql/.ssh/authorized_keys") }
   end
 
-  file '/var/lib/postgresql/.ssh/id_rsa' do
-    owner 'postgres'
-    group 'postgres'
-    mode '0700'
+  file "/var/lib/postgresql/.ssh/id_rsa" do
+    owner "postgres"
+    group "postgres"
+    mode "0700"
     backup 0
     content private_key
   end
 
-  file '/var/lib/postgresql/.ssh/id_rsa.pub' do
-    owner 'postgres'
-    group 'postgres'
-    mode '0700'
+  file "/var/lib/postgresql/.ssh/id_rsa.pub" do
+    owner "postgres"
+    group "postgres"
+    mode "0700"
     backup 0
     content public_key
   end
 
-  bash 'configure-authorized-keys-for-postgres' do
-    code 'cat /var/lib/postgresql/.ssh/id_rsa.pub >> /var/lib/postgresql/.ssh/authorized_keys'
+  bash "configure-authorized-keys-for-postgres" do
+    code "cat /var/lib/postgresql/.ssh/id_rsa.pub >> /var/lib/postgresql/.ssh/authorized_keys"
     not_if 'grep "`cat /var/lib/postgresql/.ssh/id_rsa.pub`" /var/lib/postgresql/.ssh/authorized_keys'
   end
 end

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/mysql_failover.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/mysql_failover.rb
@@ -3,42 +3,42 @@
 # Recipe:: mysql_failover
 #
 
-bash 'remove-replication-configuration' do
-  code 'rm /db/mysql/master.info'
-  only_if { ::File.exist?('/db/mysql/master.info') }
+bash "remove-replication-configuration" do
+  code "rm /db/mysql/master.info"
+  only_if { ::File.exist?("/db/mysql/master.info") }
 end
 
-bash 'remove-replication-configuration' do
-  code 'rm /etc/mysql.d/replication.cnf'
-  only_if { ::File.exist?('/etc/mysql.d/replication.cnf') }
+bash "remove-replication-configuration" do
+  code "rm /etc/mysql.d/replication.cnf"
+  only_if { ::File.exist?("/etc/mysql.d/replication.cnf") }
 end
 
-bash 'remote-replication-relay-files' do
-  code 'rm /db/mysql/*relay*'
-  only_if { ::File.exist?('/db/mysql/relay-log.info') }
+bash "remote-replication-relay-files" do
+  code "rm /db/mysql/*relay*"
+  only_if { ::File.exist?("/db/mysql/relay-log.info") }
 end
 
-case node['engineyard']['environment']['db_stack_name']
-when 'mysql5_0', 'mysql5_1'
-  ruby_block 'promote-5.0-5.1-slave-to-master' do
+case node["engineyard"]["environment"]["db_stack_name"]
+when "mysql5_0", "mysql5_1"
+  ruby_block "promote-5.0-5.1-slave-to-master" do
     block do
-      `mysql -u root -p#{node['owner_pass']} -e 'stop slave;'`
-      `mysql -u root -p#{node['owner_pass']} -e 'CHANGE master TO master_host='';'`
-      `mysql -u root -p#{node['owner_pass']} -e 'SET global read_only = 0;'`
-      `mysql -u root -p#{node['owner_pass']} -e 'flush privileges;'`
+      `mysql -u root -p#{node["owner_pass"]} -e 'stop slave;'`
+      `mysql -u root -p#{node["owner_pass"]} -e 'CHANGE master TO master_host='';'`
+      `mysql -u root -p#{node["owner_pass"]} -e 'SET global read_only = 0;'`
+      `mysql -u root -p#{node["owner_pass"]} -e 'flush privileges;'`
     end
   end
-when 'mysql5_5'
-  ruby_block 'promote-5.5-slave-to-master' do
+when "mysql5_5"
+  ruby_block "promote-5.5-slave-to-master" do
     block do
-      `mysql -u root -p#{node['owner_pass']} -e 'stop slave;'`
-      `mysql -u root -p#{node['owner_pass']} -e 'reset slave all;'`
-      `mysql -u root -p#{node['owner_pass']} -e 'SET global read_only = 0;'`
-      `mysql -u root -p#{node['owner_pass']} -e 'flush privileges;'`
+      `mysql -u root -p#{node["owner_pass"]} -e 'stop slave;'`
+      `mysql -u root -p#{node["owner_pass"]} -e 'reset slave all;'`
+      `mysql -u root -p#{node["owner_pass"]} -e 'SET global read_only = 0;'`
+      `mysql -u root -p#{node["owner_pass"]} -e 'flush privileges;'`
     end
   end
 end
 
-bash 'restart-mysql' do
-  code '/etc/init.d/mysql restart'
+bash "restart-mysql" do
+  code "/etc/init.d/mysql restart"
 end

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/mysql_failover.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/mysql_failover.rb
@@ -1,0 +1,44 @@
+#
+# Cookbook:: dr_failover
+# Recipe:: mysql_failover
+#
+
+bash 'remove-replication-configuration' do
+  code 'rm /db/mysql/master.info'
+  only_if { ::File.exist?('/db/mysql/master.info') }
+end
+
+bash 'remove-replication-configuration' do
+  code 'rm /etc/mysql.d/replication.cnf'
+  only_if { ::File.exist?('/etc/mysql.d/replication.cnf') }
+end
+
+bash 'remote-replication-relay-files' do
+  code 'rm /db/mysql/*relay*'
+  only_if { ::File.exist?('/db/mysql/relay-log.info') }
+end
+
+case node['engineyard']['environment']['db_stack_name']
+when 'mysql5_0', 'mysql5_1'
+  ruby_block 'promote-5.0-5.1-slave-to-master' do
+    block do
+      `mysql -u root -p#{node['owner_pass']} -e 'stop slave;'`
+      `mysql -u root -p#{node['owner_pass']} -e 'CHANGE master TO master_host='';'`
+      `mysql -u root -p#{node['owner_pass']} -e 'SET global read_only = 0;'`
+      `mysql -u root -p#{node['owner_pass']} -e 'flush privileges;'`
+    end
+  end
+when 'mysql5_5'
+  ruby_block 'promote-5.5-slave-to-master' do
+    block do
+      `mysql -u root -p#{node['owner_pass']} -e 'stop slave;'`
+      `mysql -u root -p#{node['owner_pass']} -e 'reset slave all;'`
+      `mysql -u root -p#{node['owner_pass']} -e 'SET global read_only = 0;'`
+      `mysql -u root -p#{node['owner_pass']} -e 'flush privileges;'`
+    end
+  end
+end
+
+bash 'restart-mysql' do
+  code '/etc/init.d/mysql restart'
+end

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/mysql_master_configuration.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/mysql_master_configuration.rb
@@ -4,19 +4,19 @@
 #
 
 if solo?
-  remote_file '/etc/mysql.d/logbin.cnf' do
-    source 'logbin.cnf'
-    owner 'root'
-    group 'root'
-    mode '0600'
+  remote_file "/etc/mysql.d/logbin.cnf" do
+    source "logbin.cnf"
+    owner "root"
+    group "root"
+    mode "0600"
     backup 0
   end
 
-  bash 'restart-mysql' do
-    code '/etc/init.d/mysql restart'
+  bash "restart-mysql" do
+    code "/etc/init.d/mysql restart"
   end
 end
 
 if db_server?
-  include_recipe 'eydr::install_xtrabackup'
+  include_recipe "eydr::install_xtrabackup"
 end

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/mysql_master_configuration.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/mysql_master_configuration.rb
@@ -1,0 +1,22 @@
+#
+# Cookbook:: dr_replication
+# Recipe:: mysql_master_configuration
+#
+
+if solo?
+  remote_file '/etc/mysql.d/logbin.cnf' do
+    source 'logbin.cnf'
+    owner 'root'
+    group 'root'
+    mode '0600'
+    backup 0
+  end
+
+  bash 'restart-mysql' do
+    code '/etc/init.d/mysql restart'
+  end
+end
+
+if db_server?
+  include_recipe 'eydr::install_xtrabackup'
+end

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/mysql_monitoring.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/mysql_monitoring.rb
@@ -3,8 +3,8 @@
 # Recipe:: mysql_monitoring
 #
 
-bash 'add-mysql-replication-monitoring' do
+bash "add-mysql-replication-monitoring" do
   code 'sed -i \'s|Exec "mysql" "/engineyard/bin/check_mysql.sh" "connections"|Exec "mysql" "/engineyard/bin/check_mysql.sh" "connections"\n      Exec "mysql" "/engineyard/bin/check_mysql.sh" "replication" "8000" "40000"|g\' /etc/engineyard/collectd.conf'
   not_if "grep 'replication' /etc/engineyard/collectd.conf"
-  only_if { ::File.exist?('/etc/engineyard/collectd.conf') }
+  only_if { ::File.exist?("/etc/engineyard/collectd.conf") }
 end

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/mysql_monitoring.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/mysql_monitoring.rb
@@ -1,0 +1,10 @@
+#
+# Cookbook:: dr_failover
+# Recipe:: mysql_monitoring
+#
+
+bash 'add-mysql-replication-monitoring' do
+  code 'sed -i \'s|Exec "mysql" "/engineyard/bin/check_mysql.sh" "connections"|Exec "mysql" "/engineyard/bin/check_mysql.sh" "connections"\n      Exec "mysql" "/engineyard/bin/check_mysql.sh" "replication" "8000" "40000"|g\' /etc/engineyard/collectd.conf'
+  not_if "grep 'replication' /etc/engineyard/collectd.conf"
+  only_if { ::File.exist?('/etc/engineyard/collectd.conf') }
+end

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/mysql_replication.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/mysql_replication.rb
@@ -3,41 +3,41 @@
 # Recipe:: mysql_replication
 #
 
-include_recipe 'eydr::install_xtrabackup'
+include_recipe "eydr::install_xtrabackup"
 
 # Drop slave replication settings in place
-template '/etc/mysql.d/replication.cnf' do
-  source 'replication.cnf.erb'
+template "/etc/mysql.d/replication.cnf" do
+  source "replication.cnf.erb"
   variables({
-    server_id: node['engineyard']['this'].split('-')[1].to_i(16),
-    datadir: node['datadir'],
-    short_version: node['mysql']['short_version'],
+    server_id: node["engineyard"]["this"].split("-")[1].to_i(16),
+    datadir: node["datadir"],
+    short_version: node["mysql"]["short_version"],
   })
 end
 
 # Render the script to setup replication
-template '/engineyard/bin/setup_replication.sh' do
-  source 'setup_mysql_replication.sh.erb'
-  owner 'root'
-  group 'root'
-  mode '0755'
+template "/engineyard/bin/setup_replication.sh" do
+  source "setup_mysql_replication.sh.erb"
+  owner "root"
+  group "root"
+  mode "0755"
   backup 0
   variables({
-    master_pass: node['owner_pass'],
-    initiate_public_hostname: node['dr_replication'][node['environment']['framework_env']]['initiate']['public_hostname'],
-    slave_public_hostname: node['dr_replication'][node['environment']['framework_env']]['slave']['public_hostname'],
-    master_public_hostname: node['dr_replication'][node['environment']['framework_env']]['master']['public_hostname'],
-    datadir: node['datadir'],
-    user: node['owner_name'],
-    db_name: node['engineyard']['environment']['apps'].first['database_name'],
-    db_pass: node['owner_pass'],
-    db_user: node['owner_name'],
+    master_pass: node["owner_pass"],
+    initiate_public_hostname: node["dr_replication"][node["environment"]["framework_env"]]["initiate"]["public_hostname"],
+    slave_public_hostname: node["dr_replication"][node["environment"]["framework_env"]]["slave"]["public_hostname"],
+    master_public_hostname: node["dr_replication"][node["environment"]["framework_env"]]["master"]["public_hostname"],
+    datadir: node["datadir"],
+    user: node["owner_name"],
+    db_name: node["engineyard"]["environment"]["apps"].first["database_name"],
+    db_pass: node["owner_pass"],
+    db_user: node["owner_name"],
   })
 end
 
 # Only run the setup replication script if the enable_replication flag is set to true in the attributes
-if node['establish_replication']
-  bash 'setup-replication' do
+if node["establish_replication"]
+  bash "setup-replication" do
     code "/engineyard/bin/setup_replication.sh > /home/#{node['owner_name']}/setup_replication.log 2>&1"
     timeout 7200  # default 2 hours, if you have a lot of data you may need to increase this
   end

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/mysql_replication.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/mysql_replication.rb
@@ -1,0 +1,44 @@
+#
+# Cookbook:: dr_replication
+# Recipe:: mysql_replication
+#
+
+include_recipe 'eydr::install_xtrabackup'
+
+# Drop slave replication settings in place
+template '/etc/mysql.d/replication.cnf' do
+  source 'replication.cnf.erb'
+  variables({
+    server_id: node['engineyard']['this'].split('-')[1].to_i(16),
+    datadir: node['datadir'],
+    short_version: node['mysql']['short_version'],
+  })
+end
+
+# Render the script to setup replication
+template '/engineyard/bin/setup_replication.sh' do
+  source 'setup_mysql_replication.sh.erb'
+  owner 'root'
+  group 'root'
+  mode '0755'
+  backup 0
+  variables({
+    master_pass: node['owner_pass'],
+    initiate_public_hostname: node['dr_replication'][node['environment']['framework_env']]['initiate']['public_hostname'],
+    slave_public_hostname: node['dr_replication'][node['environment']['framework_env']]['slave']['public_hostname'],
+    master_public_hostname: node['dr_replication'][node['environment']['framework_env']]['master']['public_hostname'],
+    datadir: node['datadir'],
+    user: node['owner_name'],
+    db_name: node['engineyard']['environment']['apps'].first['database_name'],
+    db_pass: node['owner_pass'],
+    db_user: node['owner_name'],
+  })
+end
+
+# Only run the setup replication script if the enable_replication flag is set to true in the attributes
+if node['establish_replication']
+  bash 'setup-replication' do
+    code "/engineyard/bin/setup_replication.sh > /home/#{node['owner_name']}/setup_replication.log 2>&1"
+    timeout 7200  # default 2 hours, if you have a lot of data you may need to increase this
+  end
+end

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_failover.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_failover.rb
@@ -1,0 +1,10 @@
+#
+# Cookbook:: dr_failover
+# Recipe:: postgresql_failover
+#
+
+bash 'promote-slave-to-master' do
+  code 'touch /tmp/postgresql.trigger'
+end
+
+# Restart postgres? Remove trigger file after restart?

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_failover.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_failover.rb
@@ -3,8 +3,8 @@
 # Recipe:: postgresql_failover
 #
 
-bash 'promote-slave-to-master' do
-  code 'touch /tmp/postgresql.trigger'
+bash "promote-slave-to-master" do
+  code "touch /tmp/postgresql.trigger"
 end
 
 # Restart postgres? Remove trigger file after restart?

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_master_configuration.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_master_configuration.rb
@@ -1,0 +1,30 @@
+#
+# Cookbook:: dr_replication
+# Recipe:: postgres_master_configuration
+#
+
+# Add 127.0.0.1/32 to pg_hba.conf file and custom_pg_hba.conf file to persist changes
+bash 'update-pg-hba-conf' do
+  code "echo 'host    replication     postgres        127.0.0.1/32              md5' >> /db/postgresql/#{node['postgresql']['short_version']}/data/pg_hba.conf"
+  not_if "grep 'host    replication     postgres        127.0.0.1/32              md5' /db/postgresql/#{node['postgresql']['short_version']}/data/pg_hba.conf"
+end
+
+bash 'update-custom-pg-hba-conf' do
+  code "echo 'host    replication     postgres        127.0.0.1/32              md5' >> /db/postgresql/#{node['postgresql']['short_version']}/custom_pg_hba.conf"
+  not_if "grep 'host    replication     postgres        127.0.0.1/32              md5' /db/postgresql/#{node['postgresql']['short_version']}/custom_pg_hba.conf"
+end
+
+# Add localhost to pg_hba.conf file and custom_pg_hba.conf file to persist changes
+bash 'update-pg-hba-conf-localhost' do
+  code "echo 'host    replication     postgres        localhost              md5' >> /db/postgresql/#{node['postgresql']['short_version']}/data/pg_hba.conf"
+  not_if "grep 'host    replication     postgres        localhost              md5' /db/postgresql/#{node['postgresql']['short_version']}/data/pg_hba.conf"
+end
+
+bash 'update-custom-pg-hba-conf-localhost' do
+  code "echo 'host    replication     postgres        localhost              md5' >> /db/postgresql/#{node['postgresql']['short_version']}/custom_pg_hba.conf"
+  not_if "grep 'host    replication     postgres        localhost              md5' /db/postgresql/#{node['postgresql']['short_version']}/custom_pg_hba.conf"
+end
+
+bash 'reload-postgres-config' do
+  code "su - postgres -c 'pg_ctl reload -D /db/postgresql/#{node['postgresql']['short_version']}/data/'"
+end

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_master_configuration.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_master_configuration.rb
@@ -4,27 +4,27 @@
 #
 
 # Add 127.0.0.1/32 to pg_hba.conf file and custom_pg_hba.conf file to persist changes
-bash 'update-pg-hba-conf' do
+bash "update-pg-hba-conf" do
   code "echo 'host    replication     postgres        127.0.0.1/32              md5' >> /db/postgresql/#{node['postgresql']['short_version']}/data/pg_hba.conf"
   not_if "grep 'host    replication     postgres        127.0.0.1/32              md5' /db/postgresql/#{node['postgresql']['short_version']}/data/pg_hba.conf"
 end
 
-bash 'update-custom-pg-hba-conf' do
+bash "update-custom-pg-hba-conf" do
   code "echo 'host    replication     postgres        127.0.0.1/32              md5' >> /db/postgresql/#{node['postgresql']['short_version']}/custom_pg_hba.conf"
   not_if "grep 'host    replication     postgres        127.0.0.1/32              md5' /db/postgresql/#{node['postgresql']['short_version']}/custom_pg_hba.conf"
 end
 
 # Add localhost to pg_hba.conf file and custom_pg_hba.conf file to persist changes
-bash 'update-pg-hba-conf-localhost' do
+bash "update-pg-hba-conf-localhost" do
   code "echo 'host    replication     postgres        localhost              md5' >> /db/postgresql/#{node['postgresql']['short_version']}/data/pg_hba.conf"
   not_if "grep 'host    replication     postgres        localhost              md5' /db/postgresql/#{node['postgresql']['short_version']}/data/pg_hba.conf"
 end
 
-bash 'update-custom-pg-hba-conf-localhost' do
+bash "update-custom-pg-hba-conf-localhost" do
   code "echo 'host    replication     postgres        localhost              md5' >> /db/postgresql/#{node['postgresql']['short_version']}/custom_pg_hba.conf"
   not_if "grep 'host    replication     postgres        localhost              md5' /db/postgresql/#{node['postgresql']['short_version']}/custom_pg_hba.conf"
 end
 
-bash 'reload-postgres-config' do
+bash "reload-postgres-config" do
   code "su - postgres -c 'pg_ctl reload -D /db/postgresql/#{node['postgresql']['short_version']}/data/'"
 end

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_monitoring.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_monitoring.rb
@@ -1,0 +1,4 @@
+#
+# Cookbook:: dr_failover
+# Recipe:: postgresql_monitoring
+#

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_replication.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_replication.rb
@@ -3,7 +3,7 @@
 # Recipe:: postgresql_replication
 #
 
-if node['postgresql']['short_version'] >= '12'
+if node["postgresql"]["short_version"] >= "12"
   execute "touch standby.signal" do
     command "touch /db/postgresql/#{node['postgresql']['short_version']}/data/standby.signal"
   end
@@ -13,72 +13,71 @@ if node['postgresql']['short_version'] >= '12'
       config_line = "primary_conninfo = 'host=127.0.0.1 port=5433 user=postgres password=#{node['owner_pass']}\npromote_trigger_file = '/tmp/postgresql.trigger'"
       file = Chef::Util::FileEdit.new("/db/postgresql/#{node['postgresql']['short_version']}/custom.conf")
       file.insert_line_if_no_match(/#{Regexp.escape(config_line)}/, config_line)
-#      file.insert_line_if_no_match("/promote_trigger_file = '/tmp/postgresql.trigger'/", "promote_trigger_file = '/tmp/postgresql.trigger'")
       file.write_file
     end
   end
 else
   # Drop slave replication settings in place
   template "/db/postgresql/#{node['postgresql']['short_version']}/data/recovery.conf" do
-    source 'recovery.conf.erb'
-    owner 'postgres'
-    group 'postgres'
-    mode '0600'
+    source "recovery.conf.erb"
+    owner "postgres"
+    group "postgres"
+    mode "0600"
     backup 0
     variables(
-      standby_mode: 'on',
-      primary_host: '127.0.0.1',
+      standby_mode: "on",
+      primary_host: "127.0.0.1",
       primary_port: 5433,
-      primary_user: 'postgres',
-      primary_password: node['owner_pass'],
-      trigger_file: '/tmp/postgresql.trigger'
+      primary_user: "postgres",
+      primary_password: node["owner_pass"],
+      trigger_file: "/tmp/postgresql.trigger"
     )
   end
 end
 
 # Ensure the wal directory exists
 directory "/db/postgresql/#{node['postgresql']['short_version']}/wal/" do
-  owner 'postgres'
-  group 'postgres'
-  mode '0755'
+  owner "postgres"
+  group "postgres"
+  mode "0755"
   recursive true
   action :create
 end
 
-if node['postgresql']['short_version'] >= '15'
+if node["postgresql"]["short_version"] >= "15"
   # Render the script to setup replication
-  template '/engineyard/bin/setup_replication.sh' do
-    source 'setup_postgres_15_replication.sh.erb'
-    owner 'root'
-    group 'root'
-    mode '0755'
+  template "/engineyard/bin/setup_replication.sh" do
+    source "setup_postgres_15_replication.sh.erb"
+    owner "root"
+    group "root"
+    mode "0755"
     backup 0
     variables(
-      master_public_hostname: node['dr_replication'][node['dna']['environment']['framework_env']]['master']['public_hostname'],
-      slave_public_hostname: node['dr_replication'][node['dna']['environment']['framework_env']]['slave']['public_hostname'],
-      version: node['postgresql']['short_version']
+      master_public_hostname: node["dr_replication"][node["dna"]["environment"]["framework_env"]]["master"]["public_hostname"],
+      slave_public_hostname: node["dr_replication"][node["dna"]["environment"]["framework_env"]]["slave"]["public_hostname"],
+      version: node["postgresql"]["short_version"]
     )
   end
 else
   # Render the script to setup replication
-  template '/engineyard/bin/setup_replication.sh' do
-    source 'setup_postgres_replication.sh.erb'
-    owner 'root'
-    group 'root'
-    mode '0755'
+  template "/engineyard/bin/setup_replication.sh" do
+    source "setup_postgres_replication.sh.erb"
+    owner "root"
+    group "root"
+    mode "0755"
     backup 0
     variables(
-      master_public_hostname: node['dr_replication'][node['dna']['environment']['framework_env']]['master']['public_hostname'],
-      slave_public_hostname: node['dr_replication'][node['dna']['environment']['framework_env']]['slave']['public_hostname'],
-      version: node['postgresql']['short_version']
+      master_public_hostname: node["dr_replication"][node["dna"]["environment"]["framework_env"]]["master"]["public_hostname"],
+      slave_public_hostname: node["dr_replication"][node["dna"]["environment"]["framework_env"]]["slave"]["public_hostname"],
+      version: node["postgresql"]["short_version"]
     )
   end
 end
 
 # Only run the setup replication script if the enable_replication flag is set to true in the attributes
-if node['establish_replication']
-  bash 'setup-replication' do
-    code '/engineyard/bin/setup_replication.sh'
+if node["establish_replication"]
+  bash "setup-replication" do
+    code "/engineyard/bin/setup_replication.sh"
     timeout 7200  # default 2 hours, if you have a lot of data you may need to increase this
   end
 end

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_replication.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_replication.rb
@@ -1,0 +1,52 @@
+#
+# Cookbook:: dr_replication
+# Recipe:: postgresql_replication
+#
+
+# Drop slave replication settings in place
+template "/db/postgresql/#{node['postgresql']['short_version']}/data/recovery.conf" do
+  source 'recovery.conf.erb'
+  owner 'postgres'
+  group 'postgres'
+  mode '0600'
+  backup 0
+  variables(
+    standby_mode: 'on',
+    primary_host: '127.0.0.1',
+    primary_port: 5433,
+    primary_user: 'postgres',
+    primary_password: node['owner_pass'],
+    trigger_file: '/tmp/postgresql.trigger'
+  )
+end
+
+# Ensure the wal directory exists
+directory "/db/postgresql/#{node['postgresql']['short_version']}/wal/" do
+  owner 'postgres'
+  group 'postgres'
+  mode '0755'
+  recursive true
+  action :create
+end
+
+# Render the script to setup replication
+template '/engineyard/bin/setup_replication.sh' do
+  source 'setup_postgres_replication.sh.erb'
+  owner 'root'
+  group 'root'
+  mode '0755'
+  backup 0
+  variables(
+    master_public_hostname: node['dr_replication'][node['dna']['environment']['framework_env']]['master']['public_hostname'],
+    slave_public_hostname: node['dr_replication'][node['dna']['environment']['framework_env']]['slave']['public_hostname'],
+    version: node['postgresql']['short_version']
+  )
+end
+
+# Only run the setup replication script if the enable_replication flag is set to true in the attributes
+if node['establish_replication']
+  bash 'setup-replication' do
+    code '/engineyard/bin/setup_replication.sh'
+    timeout 7200  # default 2 hours, if you have a lot of data you may need to increase this
+  end
+end

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_replication.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_replication.rb
@@ -5,13 +5,15 @@
 
 postgres_version = node["postgresql"]["short_version"]
 
+Chef::Log.info("PostgreSQL Version: #{postgres_version}")
+
 if postgres_version_gte?("12")
   execute "touch standby.signal" do
     command "touch /db/postgresql/#{node['postgresql']['short_version']}/data/standby.signal"
   end
 
   bash "add primary_conninfo in postgresql.conf" do
-    user 'postgres'
+    user "postgres"
     code <<-EOS
       cat >>/db/postgresql/#{node['postgresql']['short_version']}/data/postgresql.conf <<EOL
 primary_conninfo = 'host=127.0.0.1 port=5433 user=postgres password=#{node['owner_pass']}'
@@ -20,7 +22,7 @@ primary_conninfo = 'host=127.0.0.1 port=5433 user=postgres password=#{node['owne
   end
 
   bash "add promote_trigger_file in postgresql.conf" do
-    user 'postgres'
+    user "postgres"
     code <<-EOS
       cat >>/db/postgresql/#{node['postgresql']['short_version']}/data/postgresql.conf <<EOL
 promote_trigger_file = '/tmp/postgresql.trigger'

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_replication.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_replication.rb
@@ -3,21 +3,37 @@
 # Recipe:: postgresql_replication
 #
 
-# Drop slave replication settings in place
-template "/db/postgresql/#{node['postgresql']['short_version']}/data/recovery.conf" do
-  source 'recovery.conf.erb'
-  owner 'postgres'
-  group 'postgres'
-  mode '0600'
-  backup 0
-  variables(
-    standby_mode: 'on',
-    primary_host: '127.0.0.1',
-    primary_port: 5433,
-    primary_user: 'postgres',
-    primary_password: node['owner_pass'],
-    trigger_file: '/tmp/postgresql.trigger'
-  )
+if node['postgresql']['short_version'] >= '12'
+  execute "touch standby.signal" do
+    command "touch /db/postgresql/#{node['postgresql']['short_version']}/data/standby.signal"
+  end
+
+  ruby_block "add replication settings" do
+    block do
+      config_line = "primary_conninfo = 'host=127.0.0.1 port=5433 user=postgres password=#{node['owner_pass']}\npromote_trigger_file = '/tmp/postgresql.trigger'"
+      file = Chef::Util::FileEdit.new("/db/postgresql/#{node['postgresql']['short_version']}/custom.conf")
+      file.insert_line_if_no_match(/#{Regexp.escape(config_line)}/, config_line)
+#      file.insert_line_if_no_match("/promote_trigger_file = '/tmp/postgresql.trigger'/", "promote_trigger_file = '/tmp/postgresql.trigger'")
+      file.write_file
+    end
+  end
+else
+  # Drop slave replication settings in place
+  template "/db/postgresql/#{node['postgresql']['short_version']}/data/recovery.conf" do
+    source 'recovery.conf.erb'
+    owner 'postgres'
+    group 'postgres'
+    mode '0600'
+    backup 0
+    variables(
+      standby_mode: 'on',
+      primary_host: '127.0.0.1',
+      primary_port: 5433,
+      primary_user: 'postgres',
+      primary_password: node['owner_pass'],
+      trigger_file: '/tmp/postgresql.trigger'
+    )
+  end
 end
 
 # Ensure the wal directory exists
@@ -29,18 +45,34 @@ directory "/db/postgresql/#{node['postgresql']['short_version']}/wal/" do
   action :create
 end
 
-# Render the script to setup replication
-template '/engineyard/bin/setup_replication.sh' do
-  source 'setup_postgres_replication.sh.erb'
-  owner 'root'
-  group 'root'
-  mode '0755'
-  backup 0
-  variables(
-    master_public_hostname: node['dr_replication'][node['dna']['environment']['framework_env']]['master']['public_hostname'],
-    slave_public_hostname: node['dr_replication'][node['dna']['environment']['framework_env']]['slave']['public_hostname'],
-    version: node['postgresql']['short_version']
-  )
+if node['postgresql']['short_version'] >= '15'
+  # Render the script to setup replication
+  template '/engineyard/bin/setup_replication.sh' do
+    source 'setup_postgres_15_replication.sh.erb'
+    owner 'root'
+    group 'root'
+    mode '0755'
+    backup 0
+    variables(
+      master_public_hostname: node['dr_replication'][node['dna']['environment']['framework_env']]['master']['public_hostname'],
+      slave_public_hostname: node['dr_replication'][node['dna']['environment']['framework_env']]['slave']['public_hostname'],
+      version: node['postgresql']['short_version']
+    )
+  end
+else
+  # Render the script to setup replication
+  template '/engineyard/bin/setup_replication.sh' do
+    source 'setup_postgres_replication.sh.erb'
+    owner 'root'
+    group 'root'
+    mode '0755'
+    backup 0
+    variables(
+      master_public_hostname: node['dr_replication'][node['dna']['environment']['framework_env']]['master']['public_hostname'],
+      slave_public_hostname: node['dr_replication'][node['dna']['environment']['framework_env']]['slave']['public_hostname'],
+      version: node['postgresql']['short_version']
+    )
+  end
 end
 
 # Only run the setup replication script if the enable_replication flag is set to true in the attributes

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/ssh_tunnel.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/ssh_tunnel.rb
@@ -3,7 +3,7 @@
 # Recipe:: ssh_tunnel
 #
 
-case node.engineyard.environment['db_stack_name']
+case node.engineyard.environment["db_stack_name"]
 when /mysql(.*)/
   connect_port = 13306
   forward_port = 3306
@@ -12,17 +12,17 @@ when /postgres(.*)/
   forward_port = 5432
 end
 
-tunnel_name = 'ssh_tunnel'
+tunnel_name = "ssh_tunnel"
 
 # fill in missing information below
 tunnel_vars = {
   # the host hostname (an IP will work) to ssh to
-  ssh_hostname: node['dr_replication'][node['dna']['environment']['framework_env']]['master']['public_hostname'],
+  ssh_hostname: node["dr_replication"][node["dna"]["environment"]["framework_env"]]["master"]["public_hostname"],
   # only change this if using a non-default ssh port on the destination host,
   # such as when connecting through a gateway
   ssh_port: 22,
   # the system user account to use when logging into the destination host
-  ssh_user: node['owner_name'],
+  ssh_user: node["owner_name"],
   # the path to the private key on the instance the tunnel is from
   ssh_private_key: "/home/#{node['owner_name']}/.ssh/eydr_key",
   # the path to the public key on the instance the tunnel is from
@@ -31,14 +31,14 @@ tunnel_vars = {
   connect_port: connect_port,
   # the host on the remote side (or local side for a reverse tunnel)
   # that the :connect_port will be forwarded to
-  forward_host: 'localhost',
+  forward_host: "localhost",
   # the port on :forward_host that :connect_port will be forwarded to
   forward_port: forward_port,
   # valid values: FWD, REV, DUAL. Determines what kind of tunnel(s) to create
   # DUAL means create both a forward and reverse tunnel
-  tunnel_direction: 'DUAL',
+  tunnel_direction: "DUAL",
   # the path to the ssh executable to use when making the ssh connection
-  ssh_cmd: '/usr/bin/ssh',
+  ssh_cmd: "/usr/bin/ssh",
   # whether or not to use StrictHostKeyChecking when making the ssh connection
   skip_hostkey_auth: false,
   # the path to the known hosts file with the public key of the remote server
@@ -49,29 +49,29 @@ tunnel_vars = {
   # key is written to here.  It's also even better to copy that key entry to
   # a file somewhere on an EBS volume and use that file's path here to ensure
   # that it won't be wiped after an instance restart (terminate and rebuild)
-  ssh_known_hosts: '',
+  ssh_known_hosts: "",
 }
 
 # set this to match on the node[:instance_role] of the instance the tunnel
 # should be set up on
-if ['solo', 'db_master'].include?(node['dna']['instance_role'])
+if ["solo", "db_master"].include?(node["dna"]["instance_role"])
 
   template "/etc/init.d/#{tunnel_name}" do
-    source 'ssh_tunnel.initd.erb'
-    owner 'root'
-    group 'root'
-    mode '0755'
+    source "ssh_tunnel.initd.erb"
+    owner "root"
+    group "root"
+    mode "0755"
     variables(tunnel_vars)
   end
 
   template "/etc/monit.d/#{tunnel_name}.monitrc" do
-    source 'ssh_tunnel.monitrc.erb'
-    owner node['owner_name']
-    group node['owner_name']
-    mode '0644'
+    source "ssh_tunnel.monitrc.erb"
+    owner node["owner_name"]
+    group node["owner_name"]
+    mode "0644"
     variables(tunnel_vars)
   end
 
-  execute 'monit quit'
+  execute "monit quit"
 
 end

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/ssh_tunnel.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/ssh_tunnel.rb
@@ -1,0 +1,77 @@
+#
+# Cookbook:: eydr
+# Recipe:: ssh_tunnel
+#
+
+case node.engineyard.environment['db_stack_name']
+when /mysql(.*)/
+  connect_port = 13306
+  forward_port = 3306
+when /postgres(.*)/
+  connect_port = 5433
+  forward_port = 5432
+end
+
+tunnel_name = 'ssh_tunnel'
+
+# fill in missing information below
+tunnel_vars = {
+  # the host hostname (an IP will work) to ssh to
+  ssh_hostname: node['dr_replication'][node['dna']['environment']['framework_env']]['master']['public_hostname'],
+  # only change this if using a non-default ssh port on the destination host,
+  # such as when connecting through a gateway
+  ssh_port: 22,
+  # the system user account to use when logging into the destination host
+  ssh_user: node['owner_name'],
+  # the path to the private key on the instance the tunnel is from
+  ssh_private_key: "/home/#{node['owner_name']}/.ssh/eydr_key",
+  # the path to the public key on the instance the tunnel is from
+  ssh_public_key: "/home/#{node['owner_name']}/.ssh/eydr_key.pub",
+  # the port that will be being forwarded
+  connect_port: connect_port,
+  # the host on the remote side (or local side for a reverse tunnel)
+  # that the :connect_port will be forwarded to
+  forward_host: 'localhost',
+  # the port on :forward_host that :connect_port will be forwarded to
+  forward_port: forward_port,
+  # valid values: FWD, REV, DUAL. Determines what kind of tunnel(s) to create
+  # DUAL means create both a forward and reverse tunnel
+  tunnel_direction: 'DUAL',
+  # the path to the ssh executable to use when making the ssh connection
+  ssh_cmd: '/usr/bin/ssh',
+  # whether or not to use StrictHostKeyChecking when making the ssh connection
+  skip_hostkey_auth: false,
+  # the path to the known hosts file with the public key of the remote server
+  # only set if :skip_hostkey_auth is set to false
+  # note that if :skip_hostkey_auth is set to true then you need to make a
+  # manual connection to the remote host *before* deploying this recipe
+  # and use the path to the known_hosts file that the remote host's public
+  # key is written to here.  It's also even better to copy that key entry to
+  # a file somewhere on an EBS volume and use that file's path here to ensure
+  # that it won't be wiped after an instance restart (terminate and rebuild)
+  ssh_known_hosts: '',
+}
+
+# set this to match on the node[:instance_role] of the instance the tunnel
+# should be set up on
+if ['solo', 'db_master'].include?(node['dna']['instance_role'])
+
+  template "/etc/init.d/#{tunnel_name}" do
+    source 'ssh_tunnel.initd.erb'
+    owner 'root'
+    group 'root'
+    mode '0755'
+    variables(tunnel_vars)
+  end
+
+  template "/etc/monit.d/#{tunnel_name}.monitrc" do
+    source 'ssh_tunnel.monitrc.erb'
+    owner node['owner_name']
+    group node['owner_name']
+    mode '0644'
+    variables(tunnel_vars)
+  end
+
+  execute 'monit quit'
+
+end

--- a/custom-cookbooks/eydr/cookbooks/eydr/templates/default/authorized_keys.erb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/templates/default/authorized_keys.erb
@@ -1,0 +1,3 @@
+<% @ssh_keys.each do |key| %>
+<%= key %>
+<% end %>

--- a/custom-cookbooks/eydr/cookbooks/eydr/templates/default/clear_binlogs_from_slave.sh.erb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/templates/default/clear_binlogs_from_slave.sh.erb
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+for f in <%= @datadir %>/master-bin*;
+do
+    ionice -c3 rm -f $f;
+done
+
+rm $0

--- a/custom-cookbooks/eydr/cookbooks/eydr/templates/default/dotmytop.erb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/templates/default/dotmytop.erb
@@ -1,0 +1,6 @@
+user=root
+pass=<%= @master_pass %>
+delay=2
+idle=0
+sort=1
+host=localhost

--- a/custom-cookbooks/eydr/cookbooks/eydr/templates/default/lock_tables.sql.erb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/templates/default/lock_tables.sql.erb
@@ -1,0 +1,23 @@
+create database IF NOT EXISTS <%= @dbname %> 
+<%= case @dbencoding
+when /UTF-8/i then
+"CHARACTER SET utf8 COLLATE utf8_general_ci"
+end %>
+;
+
+CREATE TABLE IF NOT EXISTS <%= @dbname %>.<%= @locktable %> (
+  master_lock varchar(255) default NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+GRANT ALL PRIVILEGES 
+ON *.*
+TO root@'%'
+IDENTIFIED BY '<%= @dbpass %>';
+
+use <%= @dbname %>;
+insert into <%= @locktable %>  (master_lock) values('<%= "http://#{@master}/haproxy/monitor" %>');
+
+GRANT REPLICATION SLAVE 
+ON *.*
+TO 'replication'@'%' 
+IDENTIFIED BY '<%= @dbpass %>';

--- a/custom-cookbooks/eydr/cookbooks/eydr/templates/default/recovery.conf.erb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/templates/default/recovery.conf.erb
@@ -1,0 +1,3 @@
+standby_mode = '<%= @standby_mode %>'
+primary_conninfo = 'host=<%= @primary_host %> port=<%= @primary_port %> user=<%= @primary_user %> password=<%= @primary_password %>'
+trigger_file = '<%= @trigger_file %>'

--- a/custom-cookbooks/eydr/cookbooks/eydr/templates/default/replication.cnf.erb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/templates/default/replication.cnf.erb
@@ -1,0 +1,11 @@
+[mysqld]
+server-id                       = <%= @server_id %>
+read-only
+relay-log                       = <%= @datadir %>/slave-relay-bin
+relay-log-index                 = <%= @datadir %>/slave-relay-bin.index
+log-bin                         = <%= @datadir %>/master-bin
+log-bin-index                   = <%= @datadir %>/master-bin.index
+log-slave-updates               = 1
+<% if @short_version >= '5.1' %>
+binlog_format                   = mixed
+<% end %>

--- a/custom-cookbooks/eydr/cookbooks/eydr/templates/default/setup_mysql_replication.sh.erb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/templates/default/setup_mysql_replication.sh.erb
@@ -1,0 +1,31 @@
+#!/bin/sh
+/etc/init.d/mysql stop
+
+rm -rf <%= @datadir %>*
+
+ssh -i /home/<%= @user %>/.ssh/eydr_key -p 22 -o StrictHostKeyChecking=no -o TCPKeepAlive=yes <%= @db_user %>@<%= @initiate_public_hostname %> 'sudo innobackupex --user root --pass <%= @master_pass %> --slave-info --safe-slave-backup --compress --stream=xbstream /doesntneedtoexist | ssh -i /home/<%= @user %>/.ssh/eydr_key -o StrictHostKeyChecking=no -o TCPKeepAlive=yes <%= @user %>@<%= @slave_public_hostname %> "sudo xbstream -x -C <%= @datadir %>"'
+
+cd <%= @datadir %> && for bf in `find . -iname "*\.qp"`; do qpress -df $bf $(dirname $bf) && rm $bf; done
+
+innobackupex --apply-log --use-memory=1G <%= @datadir %>/
+
+chown -R mysql:mysql /db/mysql/
+
+/etc/init.d/mysql start
+
+slave_status=`mysql -u root -p<%= @master_pass %> -e "show slave status \G"`
+if [ ! -z "$slave_status" ]; then mysql -u root -p<%= @master_pass %> -e "stop slave"; fi
+
+mysql -u root -p<%= @master_pass %> -e "GRANT ALL PRIVILEGES ON <%= @db_name %>.* TO '<%= @db_user %>'@'%' IDENTIFIED BY '<%= @db_pass %>';"
+
+<% if @initiate_public_hostname == @master_public_hostname %>
+master_log_file=`cat <%= @datadir %>xtrabackup_binlog_info | awk '{print $1}'`
+master_log_pos=`cat <%= @datadir %>xtrabackup_binlog_info | awk '{print $2}'`
+mysql -u root -p<%= @master_pass %> -e "CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_PORT=13306, MASTER_USER='replication', MASTER_PASSWORD='<%= @master_pass %>', MASTER_LOG_FILE='$master_log_file', MASTER_LOG_POS=$master_log_pos ;"
+<% else %>
+master_log_file=`cat <%= @datadir %>/xtrabackup_slave_info | awk '{print $4}'`
+master_log_pos=`cat <%= @datadir %>/xtrabackup_slave_info | awk '{print $5}'`
+mysql -u root -p<%= @master_pass %> -e "CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_PORT=13306, MASTER_USER='replication', MASTER_PASSWORD='<%= @master_pass %>', $master_log_file $master_log_pos;"
+<% end %>
+
+mysql -u root -p<%= @master_pass %> -e "start slave;"

--- a/custom-cookbooks/eydr/cookbooks/eydr/templates/default/setup_postgres_15_replication.sh.erb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/templates/default/setup_postgres_15_replication.sh.erb
@@ -2,9 +2,9 @@
 systemctl stop postgresql.service
 su - postgres -c "ssh -o StrictHostKeyChecking=no postgres@<%= @master_public_hostname %> 'ssh -o StrictHostKeyChecking=no postgres@<%= @slave_public_hostname %> uname'"
 rm /db/postgresql/<%= @version %>/wal/*
-psql -U postgres -h localhost -p 5433 -c"select pg_start_backup('`date`');"
+psql -U postgres -h localhost -p 5433 -c"select pg_backup_start('`date`');"
 su - postgres -c "touch /db/postgresql/<%= @version %>/wal/00000001.history"
 su - postgres -c "rsync -avPz --delete --exclude .svn --exclude standby.signal --exclude recovery.conf --exclude recovery.py --exclude postgresql.conf --exclude pg_log --exclude pg_xlog <%= @master_public_hostname %>:/db/postgresql/<%= @version %>/data/ /db/postgresql/<%= @version %>/data/"
 find /db/postgresql/<%= @version %>/data/pg_xlog -type f | xargs rm -f
-psql -U postgres -h localhost -p 5433 -c"select pg_stop_backup();"
+psql -U postgres -h localhost -p 5433 -c"select pg_backup_stop();"
 systemctl start postgresql.service

--- a/custom-cookbooks/eydr/cookbooks/eydr/templates/default/setup_postgres_replication.sh.erb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/templates/default/setup_postgres_replication.sh.erb
@@ -1,0 +1,10 @@
+#!/bin/sh
+systemctl stop postgresql.service
+su - postgres -c "ssh -i ~/.ssh/eydr_key -o StrictHostKeyChecking=no postgres@<%= @master_public_hostname %> 'ssh -i ~/.ssh/eydr_key -o StrictHostKeyChecking=no postgres@<%= @slave_public_hostname %> uname'"
+rm /db/postgresql/<%= @version %>/wal/*
+psql -U postgres -h localhost -p 5433 -c"select pg_start_backup('`date`');"
+su - postgres -c "touch /db/postgresql/<%= @version %>/wal/00000001.history"
+su - postgres -c "rsync -avPz -e 'ssh -i .ssh/eydr_key' --delete --exclude .svn --exclude recovery.conf --exclude recovery.py --exclude postgresql.conf --exclude pg_log --exclude pg_xlog <%= @master_public_hostname %>:/db/postgresql/<%= @version %>/data/ /db/postgresql/<%= @version %>/data/"
+find /db/postgresql/<%= @version %>/data/pg_xlog -type f | xargs rm -f
+psql -U postgres -h localhost -p 5433 -c"select pg_stop_backup();"
+systemctl start postgresql.service

--- a/custom-cookbooks/eydr/cookbooks/eydr/templates/default/ssh_tunnel.initd.erb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/templates/default/ssh_tunnel.initd.erb
@@ -1,0 +1,79 @@
+#!/sbin/runscript
+
+PIDFILE=/var/run/${SVCNAME}.pid
+
+# connection params
+SSH_HOST='<%= @ssh_hostname %>'
+SSH_PORT=<%= @ssh_port %>
+SSH_USER='<%= @ssh_user %>'
+SSH_KEY='<%= @ssh_private_key %>'
+SSH_KNOWN_HOSTS='<%= @ssh_known_hosts %>'
+
+# forwarding params
+CONNECT_PORT=<%= @connect_port %>            # local connection port
+FORWARD_HOST='<%= @forward_host %>'
+FORWARD_PORT=<%= @forward_port %>               # mysql port
+
+# forwarding options
+# FWD -> Standard port forward using -L
+# REV -> Reverse tunnel using -R
+# DUAL -> Bi-directional, useful for binary log purge scripts
+DIRECTION="<%= @tunnel_direction %>"
+
+CMD="<%= @ssh_cmd %>"
+
+depend() {
+    use net
+}
+ 
+start() {
+    ebegin "Starting ssh tunnel"
+    
+    FORWARD_TYPE="-L"
+    if [ "$DIRECTION" = "REV" ]
+    then
+      FORWARD_TYPE="-R"
+    elif [ "$DIRECTION" = "DUAL" ]
+	then
+      FORWARD_TYPE="-R ${CONNECT_PORT}:${FORWARD_HOST}:${FORWARD_PORT} -L" 
+    fi
+    
+    ARGS="-f -p ${SSH_PORT} -N $FORWARD_TYPE ${CONNECT_PORT}:${FORWARD_HOST}:${FORWARD_PORT} ${SSH_USER}@${SSH_HOST}"
+    
+    if [ -n "$SSH_KEY" ]
+    then
+        ARGS="-i ${SSH_KEY} ${ARGS}"
+    fi
+    
+    if [ -n "$SSH_KNOWN_HOSTS" ]
+    then
+        ARGS="-o UserKnownHostsFile=${SSH_KNOWN_HOSTS} ${ARGS}"
+    else
+        ARGS="-o StrictHostKeyChecking=no ${ARGS}"
+    fi
+    
+    start-stop-daemon --start --pidfile ${PIDFILE} --exec ${CMD} -- ${ARGS}
+    pid="$(ps aux | grep "[s]sh.*${ARGS}" | awk '{print $2}')";
+    echo $pid > ${PIDFILE}
+    
+    eend $? "Failed to start ssh tunnel"
+} 
+
+stop() {
+    ebegin "Stopping ssh tunnel"
+    
+    start-stop-daemon --stop -o --pidfile ${PIDFILE}
+    rm ${PIDFILE}
+    
+    eend $? "Failed to stop ssh tunnel"
+}
+
+restart() {
+    ebegin "Restarting ssh tunnel"
+    
+    svc_stop
+    svc_start
+    
+    eend $? "Failed to restart ssh tunnel"
+}
+

--- a/custom-cookbooks/eydr/cookbooks/eydr/templates/default/ssh_tunnel.initd.erb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/templates/default/ssh_tunnel.initd.erb
@@ -1,6 +1,20 @@
-#!/sbin/runscript
+#!/bin/sh
 
-PIDFILE=/var/run/${SVCNAME}.pid
+### BEGIN INIT INFO
+# Provides:          ssh_tunnel
+# Required-Start:  $network $remote_fs $syslog
+# Required-Stop:   $network $remote_fs $syslog
+# Default-Start:   2 3 4 5
+# Default-Stop:
+# Description:     Persistent SSH Tunnel to from port 5433 on this server to port 5432 on external server
+### END INIT INFO
+
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+. /lib/lsb/init-functions
+
+BASENAME=ssh_tunnel
+PIDFILE=/var/run/${BASENAME}.pid
+CMD=/usr/bin/ssh
 
 # connection params
 SSH_HOST='<%= @ssh_hostname %>'
@@ -20,60 +34,56 @@ FORWARD_PORT=<%= @forward_port %>               # mysql port
 # DUAL -> Bi-directional, useful for binary log purge scripts
 DIRECTION="<%= @tunnel_direction %>"
 
-CMD="<%= @ssh_cmd %>"
+case "$1" in
+start)
+        log_daemon_msg "Starting ssh_tunnel" "$BASENAME"
+        FORWARD_TYPE="-L"
+        if [ "$DIRECTION" = "REV" ]
+        then
+          FORWARD_TYPE="-R"
+        elif [ "$DIRECTION" = "DUAL" ]
+            then
+          FORWARD_TYPE="-R $CONNECT_PORT:$FORWARD_HOST:$FORWARD_PORT -L"
+        fi
 
-depend() {
-    use net
-}
- 
-start() {
-    ebegin "Starting ssh tunnel"
-    
-    FORWARD_TYPE="-L"
-    if [ "$DIRECTION" = "REV" ]
-    then
-      FORWARD_TYPE="-R"
-    elif [ "$DIRECTION" = "DUAL" ]
-	then
-      FORWARD_TYPE="-R ${CONNECT_PORT}:${FORWARD_HOST}:${FORWARD_PORT} -L" 
-    fi
-    
-    ARGS="-f -p ${SSH_PORT} -N $FORWARD_TYPE ${CONNECT_PORT}:${FORWARD_HOST}:${FORWARD_PORT} ${SSH_USER}@${SSH_HOST}"
-    
-    if [ -n "$SSH_KEY" ]
-    then
-        ARGS="-i ${SSH_KEY} ${ARGS}"
-    fi
-    
-    if [ -n "$SSH_KNOWN_HOSTS" ]
-    then
-        ARGS="-o UserKnownHostsFile=${SSH_KNOWN_HOSTS} ${ARGS}"
-    else
-        ARGS="-o StrictHostKeyChecking=no ${ARGS}"
-    fi
-    
-    start-stop-daemon --start --pidfile ${PIDFILE} --exec ${CMD} -- ${ARGS}
-    pid="$(ps aux | grep "[s]sh.*${ARGS}" | awk '{print $2}')";
-    echo $pid > ${PIDFILE}
-    
-    eend $? "Failed to start ssh tunnel"
-} 
+        ARGS="-f -p $SSH_PORT -N $FORWARD_TYPE $CONNECT_PORT:$FORWARD_HOST:$FORWARD_PORT $SSH_USER@$SSH_HOST"
 
-stop() {
-    ebegin "Stopping ssh tunnel"
-    
-    start-stop-daemon --stop -o --pidfile ${PIDFILE}
-    rm ${PIDFILE}
-    
-    eend $? "Failed to stop ssh tunnel"
-}
+        if [ -n "$SSH_KEY" ]
+        then
+            ARGS="-i $SSH_KEY $ARGS"
+        fi
 
-restart() {
-    ebegin "Restarting ssh tunnel"
-    
-    svc_stop
-    svc_start
-    
-    eend $? "Failed to restart ssh tunnel"
-}
+        if [ -n "$SSH_KNOWN_HOSTS" ]
+        then
+            ARGS="-o UserKnownHostsFile=$SSH_KNOWN_HOSTS $ARGS"
+        else
+            ARGS="-o StrictHostKeyChecking=no $ARGS"
+        fi
 
+        start-stop-daemon --quiet --oknodo --start --pidfile $PIDFILE --exec $CMD -- $ARGS || return 2
+        pid="$(ps aux | grep "[s]sh.*$ARGS" | awk '{print $2}')";
+        echo $pid > $PIDFILE
+
+        log_end_msg $?
+        ;;
+stop)
+        log_daemon_msg "Stopping ssh tunnel" "$BASENAME"
+
+        start-stop-daemon --stop -o --pidfile $PIDFILE
+
+        log_end_msg $?
+
+        rm $PIDFILE
+        ;;
+restart)
+        log_daemon_msg "Restarting ssh tunnel" "$BASENAME"
+
+        $0 stop && sleep 2 && $0 start
+
+        log_end_msg $?
+        ;;
+*)
+        echo "Usage: $0 {start|stop|reload|restart|status}"
+        exit 2
+        ;;
+esac

--- a/custom-cookbooks/eydr/cookbooks/eydr/templates/default/ssh_tunnel.monitrc.erb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/templates/default/ssh_tunnel.monitrc.erb
@@ -1,0 +1,8 @@
+check process ssh_tunnel
+  with pidfile /var/run/ssh_tunnel.pid
+  start program = "/bin/sh -c '/etc/init.d/ssh_tunnel restart'"
+  stop program = "/bin/sh -c '/etc/init.d/ssh_tunnel stop'"
+  <% if @tunnel_direction != 'REV' %>
+  if failed host 127.0.0.1 port <%= @connect_port %>
+    with timeout 15 seconds then restart
+  <% end %>


### PR DESCRIPTION
Description of your patch
-------------
Added eydr recipe support for v7 stack using PostgreSQL versions 10, 11, 12, 13 and 14

Recommended Release Notes
-------------
Added eydr recipe support for v7 stack using PostgreSQL versions 10, 11, 12, 13 and 14

Estimated risk
-------------
High

Components involved
-------------
Clients using eydr recipe

Dependencies
-------------
Environments that use either MySQL or PostgreSQL as database

Description of testing done
-------------
- Create 2 v7 environments (with the other on a different region) using any of the PostgreSQL version listed below:
  - 10 (via UI)
  - 11 (via UI)
  - 12 (via Environment Variables and using changes from PR145)
  - 13 (via Environment Variables and using changes from PR145)
  - 14 (via Environment Variables and using changes from PR145)
- Follow the `README.md` file instructions to setup the pre-requisites
- Upload `eydr` custom recipe with the modified details for Master env and Slave env
- Test if replication or failover will work via modifying `eydr/attributues/replication.rb`
- For replication:
  - Once set to `true`, the Slave environment should be streaming replication (can be verified via `select * from pg_stat_wal_receiver;`)
  - Also can be verified from Master env via `select * from pg_stat_replication;`
  - Test by adding data onto Master env and check if Slave env gets the update.

QA Instructions
-------------
- Create 2 v7 environments (with the other on a different region) using any of the PostgreSQL version listed below:
  - 10 (via UI)
  - 11 (via UI)
  - 12 (via Environment Variables and using changes from PR145)
  - 13 (via Environment Variables and using changes from PR145)
  - 14 (via Environment Variables and using changes from PR145)
- Follow the `README.md` file instructions to setup the pre-requisites
- Upload `eydr` custom recipe with the modified details for Master env and Slave env
- Test if replication or failover will work via modifying `eydr/attributues/replication.rb`
- For replication:
  - Once set to `true`, the Slave environment should be streaming replication (can be verified via `select * from pg_stat_wal_receiver;`)
  - Also can be verified from Master env via `select * from pg_stat_replication;`
  - Test by adding data onto Master env and check if Slave env gets the update.