### PR TITLE
[FBZ-10512] Update SSL directive in nginx ssl conf

### DIFF
--- a/cookbooks/ey-nginx/templates/default/nginx_app.conf.erb
+++ b/cookbooks/ey-nginx/templates/default/nginx_app.conf.erb
@@ -32,8 +32,8 @@ server {
   <% if @http2 %>
     listen <%= @haproxy_nginx_port %> ssl http2 proxy_protocol;
   <% else %>
-    listen <%= @haproxy_nginx_port %> proxy_protocol;
-    listen <%= @xlb_nginx_port %> ;
+    listen <%= @haproxy_nginx_port %> proxy_protocol <%= @ssl ? 'ssl' : '' %>;
+    listen <%= @xlb_nginx_port %> <%= @ssl ? 'ssl' : '' %>;
   <% end %>
 
   #
@@ -67,7 +67,6 @@ server {
   # start up the Nginx server the password will need to be typed in every time.
   # This precludes automatic/automated web server restarts on boot or otherwise.
   #
-  ssl on;
   ssl_certificate /etc/nginx/ssl/<%= @vhost.app.name %>/<%= @vhost.app.name %>.crt;
   ssl_certificate_key /etc/nginx/ssl/<%= @vhost.app.name %>/<%= @vhost.app.name %>.key;
   include /etc/nginx/servers/<%= @vhost.app.name %>/ssl_cipher;


### PR DESCRIPTION
Description of your patch
-------------
SSL directive in nginx ssl conf is deprecated for NGINX version 1.15.0 and above - Update SSL directive in nginx ssl conf

Recommended Release Notes
-------------
Update SSL directive in nginx ssl conf

Estimated risk
-------------
High

Components involved
-------------
Apps with SSL enabled

Dependencies
-------------

Description of testing done
-------------
- Provision a v7 environment with SSL enabled for the application
- Execute `nginx -t` and verify if it is encountering warning message: `[warn] the "ssl" directive is deprecated, use the "listen ... ssl" directive instead`
- Upload the updated `ey-nginx` recipe and trigger chef run
- Execute `nginx -t` again and verify if it is now successful
- Test access to the application

QA Instructions
-------------
- Provision a v7 environment with SSL enabled for the application
- Execute `nginx -t` and verify if it is encountering warning message: `[warn] the "ssl" directive is deprecated, use the "listen ... ssl" directive instead`
- Upload the updated `ey-nginx` recipe and trigger chef run
- Execute `nginx -t` again and verify if it is now successful
- Test access to the application