### PR TITLE
[FBZ-10503] Fixed MySQL re-installation on every chef run

### DIFF
--- a/cookbooks/ey-mysql/resources/mysql_slave.rb
+++ b/cookbooks/ey-mysql/resources/mysql_slave.rb
@@ -17,14 +17,23 @@ action :action_mysql_slave do
     command "echo"
   end
 
+ def self.mysql_slave_is_slavey?
+   begin
+     foo = `mysql -e "show slave status"`
+     !foo.empty?
+   rescue
+     false
+   end
+ end
+
   ruby_block "clean up half-done install" do
     block do
       system("/etc/init.d/mysql stop")
       system("umount /db")
       FileUtils.rmdir "/db"
     end
-    action :nothing
-    only_if { ::File.exist?("/db") }
+    action :run
+    only_if { ::File.exist?("/db") && !mysql_slave_is_slavey? }
   end
 
   directory "/db" do


### PR DESCRIPTION
**Description of your patch**
Fix MySQL getting re-installed on mysql slave on every chef run

**Recommended Release Notes**
Fixed issue where MySQL getting re-installed on mysql slave on every chef run

**Estimated risk**
High

**### Components involved**
Clients who use MySQL Slave

**Dependencies**
ey-mysql

**Description of testing done**

- Create v7 environment with MySQL
- Boot Environment with a DB slave.
- Run chef and see chef logs on DB Slave instance for ruby_block[clean up half-done install] should be executed on initial chef run only. 
- Check mysql slave status `show slave status\G;`
- Run apply and this time `ruby_block[clean up half-done install]` should not be executed.

**QA Instructions**
- Create v7 environment with MySQL
- Boot Environment with a DB slave.
- Run chef and see chef logs on DB Slave instance for ruby_block[clean up half-done install] should be executed on initial chef run only. 
- Check mysql slave status `show slave status\G;`
- Run apply and this time `ruby_block[clean up half-done install]` should not be executed.