### PR TITLE
[FBZ-10515] Fix Replication for PostgreSQL 12 and above

### DIFF
--- a/cookbooks/ey-postgresql/recipes/client_config.rb
+++ b/cookbooks/ey-postgresql/recipes/client_config.rb
@@ -9,7 +9,7 @@ template "/root/.pgpass" do
   })
 end
 
-file '/root/.bash_login' do
+file "/root/.bash_login" do
   action :create_if_missing
 end
 

--- a/cookbooks/ey-postgresql/recipes/server_configure.rb
+++ b/cookbooks/ey-postgresql/recipes/server_configure.rb
@@ -124,7 +124,7 @@ if ["db_slave"].include?(node["dna"]["instance_role"])
     end
   end
 
-  if postgres_version >= "12"
+  if postgres_version_gte?("12")
     template "#{postgres_root}/#{postgres_version}/data/postgresql.conf" do
       source "postgresql12.conf.erb"
       owner "postgres"

--- a/cookbooks/ey-postgresql/templates/default/postgresql12.conf.erb
+++ b/cookbooks/ey-postgresql/templates/default/postgresql12.conf.erb
@@ -193,7 +193,7 @@ max_wal_senders = 5             # max number of walsender processes
 #wal_sender_delay = 200ms       # walsender cycle time, 1-10000 milliseconds
 
 # as per chnage in postgres version 13 `wal_keep_segments` is renamed to `wal_keep_size` https://pgpedia.info/w/wal_keep_segments.html
-<% if @postgres_version >= "13.0" %>
+<% if postgres_version_gte?("13") %>
 wal_keep_size = 2048 # in logfile segments, 16MB each; 0 disables
 <% else %>
 wal_keep_segments = 128                 # in logfile segments, 16MB each; 0 disables

--- a/cookbooks/ey-postgresql/templates/default/postgresql12.conf.erb
+++ b/cookbooks/ey-postgresql/templates/default/postgresql12.conf.erb
@@ -1,0 +1,543 @@
+# -----------------------------
+# PostgreSQL configuration file
+# -----------------------------
+#
+# This file consists of lines of the form:
+#
+#   name = value
+#
+# (The "=" is optional.)  Whitespace may be used.  Comments are introduced with
+# "#" anywhere on a line.  The complete list of parameter names and allowed
+# values can be found in the PostgreSQL documentation.
+#
+# The commented-out settings shown in this file represent the default values.
+# Re-commenting a setting is NOT sufficient to revert it to the default value;
+# you need to reload the server.
+#
+# This file is read on server startup and when the server receives a SIGHUP
+# signal.  If you edit the file on a running system, you have to SIGHUP the
+# server for the changes to take effect, or use "pg_ctl reload".  Some
+# parameters, which are marked below, require a server shutdown and restart to
+# take effect.
+#
+# Any parameter can also be given as a command-line option to the server, e.g.,
+# "postgres -c log_connections=on".  Some parameters can be changed at run time
+# with the "SET" SQL command.
+#
+# Memory units:  kB = kilobytes        Time units:  ms  = milliseconds
+#                MB = megabytes                     s   = seconds
+#                GB = gigabytes                     min = minutes
+#                                                   h   = hours
+#                                                   d   = days
+
+
+#------------------------------------------------------------------------------
+# FILE LOCATIONS
+#------------------------------------------------------------------------------
+
+# The default values of these variables are driven from the -D command-line
+# option or PGDATA environment variable, represented here as ConfigDir.
+
+data_directory = '<%= @data_directory %>'
+#hba_file = 'ConfigDir/pg_hba.conf'     # host-based authentication file
+                                        # (change requires restart)
+#ident_file = 'ConfigDir/pg_ident.conf' # ident configuration file
+                                        # (change requires restart)
+
+#------------------------------------------------------------------------------
+# CONNECTIONS AND AUTHENTICATION
+#------------------------------------------------------------------------------
+
+# - Connection Settings -
+
+listen_addresses = '*'          # what IP address(es) to listen on;
+                                        # comma-separated list of addresses;
+                                        # defaults to 'localhost', '*' = all
+                                        # (change requires restart)
+port = <%= @pg_port %>                          # (change requires restart)
+max_connections = 512                   # (change requires restart)
+# Note:  Increasing max_connections costs ~400 bytes of shared memory per
+# connection slot, plus lock space (see max_locks_per_transaction).
+#superuser_reserved_connections = 3     # (change requires restart)
+#unix_socket_directory = ''             # (change requires restart)
+#unix_socket_group = ''                 # (change requires restart)
+#unix_socket_permissions = 0777         # begin with 0 to use octal notation
+                                        # (change requires restart)
+#bonjour = off                          # advertise server via Bonjour
+                                        # (change requires restart)
+#bonjour_name = ''                      # defaults to the computer name
+                                        # (change requires restart)
+
+# - Security and Authentication -
+
+#authentication_timeout = 1min          # 1s-600s
+ssl = on                                # (change requires restart)
+ssl_cert_file = '<%= @ssl_directory %>server.crt'
+ssl_ca_file = '<%= @ssl_directory %>root.crt'
+ssl_key_file = '<%= @ssl_directory %>server.key'
+#ssl_ciphers = 'ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH'      # allowed SSL ciphers
+                                        # (change requires restart)
+<% if postgres_version_lt?("9.5") %>
+ssl_renegotiation_limit = 0     # amount of data between renegotiations
+<% end %>
+#password_encryption = on
+#db_user_namespace = off
+
+# Kerberos and GSSAPI
+#krb_server_keyfile = ''
+#krb_srvname = 'postgres'               # (Kerberos only)
+#krb_caseins_users = off
+
+# - TCP Keepalives -
+# see "man 7 tcp" for details
+
+#tcp_keepalives_idle = 0                # TCP_KEEPIDLE, in seconds;
+                                        # 0 selects the system default
+#tcp_keepalives_interval = 0            # TCP_KEEPINTVL, in seconds;
+                                        # 0 selects the system default
+#tcp_keepalives_count = 0               # TCP_KEEPCNT;
+                                        # 0 selects the system default
+
+
+#------------------------------------------------------------------------------
+# RESOURCE USAGE (except WAL)
+#------------------------------------------------------------------------------
+
+# - Memory -
+
+shared_buffers = <%= @shared_buffers %>MB
+                                        # (change requires restart)
+#temp_buffers = 8MB                     # min 800kB
+#max_prepared_transactions = 0          # zero disables the feature
+                                        # (change requires restart)
+# Note:  Increasing max_prepared_transactions costs ~600 bytes of shared memory
+# per transaction slot, plus lock space (see max_locks_per_transaction).
+# It is not advisable to set max_prepared_transactions nonzero unless you
+# actively intend to use prepared transactions.
+work_mem = <%= @work_mem %>
+maintenance_work_mem = <%= @maintenance_work_mem %>
+max_stack_depth = <%= @max_stack_depth %>
+
+# - Kernel Resource Usage -
+
+max_files_per_process = 65535
+                                        # (change requires restart)
+#shared_preload_libraries = ''          # (change requires restart)
+
+# - Cost-Based Vacuum Delay -
+
+#vacuum_cost_delay = 0ms                # 0-100 milliseconds
+#vacuum_cost_page_hit = 1               # 0-10000 credits
+#vacuum_cost_page_miss = 10             # 0-10000 credits
+#vacuum_cost_page_dirty = 20            # 0-10000 credits
+#vacuum_cost_limit = 200                # 1-10000 credits
+
+# - Background Writer -
+
+#bgwriter_delay = 200ms                 # 10-10000ms between rounds
+#bgwriter_lru_maxpages = 100            # 0-1000 max buffers written/round
+#bgwriter_lru_multiplier = 2.0          # 0-10.0 multiplier on buffers scanned/round
+
+# - Asynchronous Behavior -
+
+#effective_io_concurrency = 1           # 1-1000. 0 disables prefetching
+
+
+#------------------------------------------------------------------------------
+# WRITE AHEAD LOG
+#------------------------------------------------------------------------------
+
+# - Settings -
+
+wal_level = <%= @wal_level %> # minimal                 # minimal, archive, or hot_standby
+#fsync = on                             # turns forced synchronization on or off
+#synchronous_commit = on                # immediate fsync at commit
+#wal_sync_method = fsync                # the default is the first option
+                                        # supported by the operating system:
+                                        #   open_datasync
+                                        #   fdatasync
+                                        #   fsync
+                                        #   fsync_writethrough
+                                        #   open_sync
+#full_page_writes = on                  # recover from partial page writes
+wal_buffers = <%= @wal_buffers %>                       # min 32kB
+                                        # (change requires restart)
+wal_writer_delay = <%= @wal_writer_delay %>             # 1-10000 milliseconds
+
+#commit_delay = 0                       # range 0-100000, in microseconds
+#commit_siblings = 5                    # range 1-1000
+
+# - Checkpoints -
+
+<% if postgres_version_gte?("9.5") %>
+max_wal_size = 4800MB
+min_wal_size = 80MB
+<% else %>
+checkpoint_segments = <%= @checkpoint_segments %>
+<% end %>
+checkpoint_timeout = <%= @checkpoint_timeout %>
+#checkpoint_completion_target = 0.5     # checkpoint target duration, 0.0 - 1.0
+#checkpoint_warning = 30s               # 0 disables
+
+# - Archiving -
+
+archive_mode = on               # allows archiving to be done
+                                # (change requires restart)
+archive_command = '/bin/true'           # command to use to archive a logfile segment
+archive_timeout = <%= @archive_timeout %>               # force a logfile segment switch after this
+                                # number of seconds; 0 disables
+
+# - Streaming Replication -
+
+max_wal_senders = 5             # max number of walsender processes
+#wal_sender_delay = 200ms       # walsender cycle time, 1-10000 milliseconds
+
+# as per chnage in postgres version 13 `wal_keep_segments` is renamed to `wal_keep_size` https://pgpedia.info/w/wal_keep_segments.html
+<% if @postgres_version >= "13.0" %>
+wal_keep_size = 2048 # in logfile segments, 16MB each; 0 disables
+<% else %>
+wal_keep_segments = 128                 # in logfile segments, 16MB each; 0 disables
+<% end %>
+#vacuum_defer_cleanup_age = 0   # number of xacts by which cleanup is delayed
+primary_conninfo = 'host=<%= @primary_host %> port=<%= @pg_port %> user=<%= @primary_user %> password=<%= @primary_password %> <% if postgres_version_gte?("9.1") %>application_name=<%= @conn_app_name %><% end %>'
+promote_trigger_file = '<%= @promote_trigger_file %>'
+restore_command = 'cp /db/postgresql/<%= @postgres_version %>/wal/%f %p'
+archive_cleanup_command = 'pg_archivecleanup /db/postgresql/<%= @postgres_version %>/wal %r'
+<% if postgres_version_gte?("9.1") %>recovery_target_timeline = latest<% end %>
+
+# - Standby Servers -
+
+hot_standby = <%= @hot_standby %>                       # "on" allows queries during recovery
+<% if @postgres_version != "9.0" %>
+hot_standby_feedback = on       # needed for repmgr
+<% end %>
+
+#max_standby_archive_delay = 30s        # max delay before canceling queries
+                                        # when reading WAL from archive;
+                                        # -1 allows indefinite delay
+max_standby_streaming_delay = -1        # max delay before canceling queries
+                                        # when reading streaming WAL;
+                                        # -1 allows indefinite delay
+
+
+#------------------------------------------------------------------------------
+# QUERY TUNING
+#------------------------------------------------------------------------------
+
+# - Planner Method Configuration -
+
+#enable_bitmapscan = on
+#enable_hashagg = on
+#enable_hashjoin = on
+#enable_indexscan = on
+#enable_material = on
+#enable_mergejoin = on
+#enable_nestloop = on
+#enable_seqscan = on
+#enable_sort = on
+#enable_tidscan = on
+
+# - Planner Cost Constants -
+
+#seq_page_cost = 1.0                    # measured on an arbitrary scale
+#random_page_cost = 4.0                 # same scale as above
+#cpu_tuple_cost = 0.01                  # same scale as above
+#cpu_index_tuple_cost = 0.005           # same scale as above
+#cpu_operator_cost = 0.0025             # same scale as above
+effective_cache_size = <%= @effective_cache_size %>MB
+
+# - Genetic Query Optimizer -
+
+#geqo = on
+#geqo_threshold = 12
+#geqo_effort = 5                        # range 1-10
+#geqo_pool_size = 0                     # selects default based on effort
+#geqo_generations = 0                   # selects default based on effort
+#geqo_selection_bias = 2.0              # range 1.5-2.0
+#geqo_seed = 0.0                        # range 0.0-1.0
+
+# - Other Planner Options -
+
+default_statistics_target = <%= @default_statistics_target %>
+#constraint_exclusion = partition       # on, off, or partition
+#cursor_tuple_fraction = 0.1            # range 0.0-1.0
+#from_collapse_limit = 8
+#join_collapse_limit = 8                # 1 disables collapsing of explicit
+                                        # JOIN clauses
+
+
+#------------------------------------------------------------------------------
+# ERROR REPORTING AND LOGGING
+#------------------------------------------------------------------------------
+
+# - Where to Log -
+
+log_destination = 'csvlog'              # Valid values are combinations of
+                                        # stderr, csvlog, syslog, and eventlog,
+                                        # depending on platform.  csvlog
+                                        # requires logging_collector to be on.
+
+# This is used when logging to stderr:
+logging_collector =  <%= @logging_collector %>
+                                        # into log files. Required to be on for
+                                        # csvlogs.
+                                        # (change requires restart)
+
+# These are only used if logging_collector is on:
+log_directory = 'pg_log'                # directory where log files are written,
+                                        # can be absolute or relative to PGDATA
+#log_filename = 'postgresql-%Y-%m-%d_%H%M%S.log'        # log file name pattern,
+                                        # can include strftime() escapes
+#log_truncate_on_rotation = off         # If on, an existing log file of the
+                                        # same name as the new log file will be
+                                        # truncated rather than appended to.
+                                        # But such truncation only occurs on
+                                        # time-driven rotation, not on restarts
+                                        # or size-driven rotation.  Default is
+                                        # off, meaning append to existing files
+                                        # in all cases.
+log_rotation_age = <%= @log_rotation_age %>
+                                        # happen after that time.  0 to disable.
+log_rotation_size = <%= @log_rotation_size %>
+                                        # happen after that much log output.
+                                        # 0 disables.
+
+# These are relevant when logging to syslog:
+#syslog_facility = 'LOCAL0'
+#syslog_ident = 'postgres'
+
+#silent_mode = off                      # Run server silently.
+                                        # DO NOT USE without syslog or
+                                        # logging_collector
+                                        # (change requires restart)
+
+
+# - When to Log -
+
+#client_min_messages = notice           # values in order of decreasing detail:
+                                        #   debug5
+                                        #   debug4
+                                        #   debug3
+                                        #   debug2
+                                        #   debug1
+                                        #   log
+                                        #   notice
+                                        #   warning
+                                        #   error
+
+#log_min_messages = warning             # values in order of decreasing detail:
+                                        #   debug5
+                                        #   debug4
+                                        #   debug3
+                                        #   debug2
+                                        #   debug1
+                                        #   info
+                                        #   notice
+                                        #   warning
+                                        #   error
+                                        #   log
+                                        #   fatal
+                                        #   panic
+
+#log_min_error_statement = error        # values in order of decreasing detail:
+                                        #   debug5
+                                        #   debug4
+                                        #   debug3
+                                        #   debug2
+                                        #   debug1
+                                        #   info
+                                        #   notice
+                                        #   warning
+                                        #   error
+                                        #   log
+                                        #   fatal
+                                        #   panic (effectively off)
+
+log_min_duration_statement = 2000       # -1 is disabled, 0 logs all statements
+                                        # and their durations, > 0 logs only
+                                        # statements running at least this number
+                                        # of milliseconds
+
+
+# - What to Log -
+
+#debug_print_parse = off
+#debug_print_rewritten = off
+#debug_print_plan = off
+#debug_pretty_print = on
+#log_checkpoints = off
+#log_connections = off
+#log_disconnections = off
+#log_duration = on
+#log_error_verbosity = default          # terse, default, or verbose messages
+#log_hostname = off
+log_line_prefix = '%m: proc=%p,user=%u,db=%d,host=%r '                  # special values:
+                                        #   %a = application name
+                                        #   %u = user name
+                                        #   %d = database name
+                                        #   %r = remote host and port
+                                        #   %h = remote host
+                                        #   %p = process ID
+                                        #   %t = timestamp without milliseconds
+                                        #   %m = timestamp with milliseconds
+                                        #   %i = command tag
+                                        #   %e = SQL state
+                                        #   %c = session ID
+                                        #   %l = session line number
+                                        #   %s = session start timestamp
+                                        #   %v = virtual transaction ID
+                                        #   %x = transaction ID (0 if none)
+                                        #   %q = stop here in non-session
+                                        #        processes
+                                        #   %% = '%'
+#log_lock_waits = off                   # log lock waits >= deadlock_timeout
+#log_statement = 'none'                 # none, ddl, mod, all
+#log_temp_files = -1                    # log temporary files equal or larger
+                                        # than the specified size in kilobytes;
+                                        # -1 disables, 0 logs all temp files
+#log_timezone = unknown                 # actually, defaults to TZ environment
+                                        # setting
+
+
+#------------------------------------------------------------------------------
+# RUNTIME STATISTICS
+#------------------------------------------------------------------------------
+
+# - Query/Index Statistics Collector -
+
+#track_activities = on
+#track_counts = on
+#track_functions = none                 # none, pl, all
+#track_activity_query_size = 1024
+#update_process_title = on
+#stats_temp_directory = 'pg_stat_tmp'
+
+
+# - Statistics Monitoring -
+
+#log_parser_stats = off
+#log_planner_stats = off
+#log_executor_stats = off
+#log_statement_stats = off
+
+
+#------------------------------------------------------------------------------
+# AUTOVACUUM PARAMETERS
+#------------------------------------------------------------------------------
+
+#autovacuum = on                        # Enable autovacuum subprocess?  'on'
+                                        # requires track_counts to also be on.
+log_autovacuum_min_duration = 2000      # -1 disables, 0 logs all actions and
+                                        # their durations, > 0 logs only
+                                        # actions running at least this number
+                                        # of milliseconds.
+#autovacuum_max_workers = 3             # max number of autovacuum subprocesses
+#autovacuum_naptime = 1min              # time between autovacuum runs
+#autovacuum_vacuum_threshold = 50       # min number of row updates before
+                                        # vacuum
+#autovacuum_analyze_threshold = 50      # min number of row updates before
+                                        # analyze
+#autovacuum_vacuum_scale_factor = 0.2   # fraction of table size before vacuum
+#autovacuum_analyze_scale_factor = 0.1  # fraction of table size before analyze
+#autovacuum_freeze_max_age = 200000000  # maximum XID age before forced vacuum
+                                        # (change requires restart)
+#autovacuum_vacuum_cost_delay = 20ms    # default vacuum cost delay for
+                                        # autovacuum, in milliseconds;
+                                        # -1 means use vacuum_cost_delay
+#autovacuum_vacuum_cost_limit = -1      # default vacuum cost limit for
+                                        # autovacuum, -1 means use
+                                        # vacuum_cost_limit
+
+
+#------------------------------------------------------------------------------
+# CLIENT CONNECTION DEFAULTS
+#------------------------------------------------------------------------------
+
+# - Statement Behavior -
+
+#search_path = '"$user",public'         # schema names
+#default_tablespace = ''                # a tablespace name, '' uses the default
+#temp_tablespaces = ''                  # a list of tablespace names, '' uses
+                                        # only default tablespace
+#check_function_bodies = on
+#default_transaction_isolation = 'read committed'
+#default_transaction_read_only = off
+#session_replication_role = 'origin'
+#statement_timeout = 0                  # in milliseconds, 0 is disabled
+#vacuum_freeze_min_age = 50000000
+#vacuum_freeze_table_age = 150000000
+#bytea_output = 'hex'                   # hex, escape
+#xmlbinary = 'base64'
+#xmloption = 'content'
+
+# - Locale and Formatting -
+
+datestyle = 'iso, mdy'
+#intervalstyle = 'postgres'
+timezone = <%= @timezone %>                     # actually, defaults to TZ environment
+                                        # setting
+#timezone_abbreviations = 'Default'     # Select the set of available time zone
+                                        # abbreviations.  Currently, there are
+                                        #   Default
+                                        #   Australia
+                                        #   India
+                                        # You can create your own file in
+                                        # share/timezonesets/.
+#extra_float_digits = 0                 # min -15, max 3
+#client_encoding = sql_ascii            # actually, defaults to database
+                                        # encoding
+
+# These settings are initialized by initdb, but they can be changed.
+lc_messages = 'C'                       # locale for system error message
+                                        # strings
+lc_monetary = 'C'                       # locale for monetary formatting
+lc_numeric = 'C'                        # locale for number formatting
+lc_time = 'C'                           # locale for time formatting
+
+# default configuration for text search
+default_text_search_config = 'pg_catalog.english'
+
+# - Other Defaults -
+
+#dynamic_library_path = '$libdir'
+#local_preload_libraries = ''
+
+
+#------------------------------------------------------------------------------
+# LOCK MANAGEMENT
+#------------------------------------------------------------------------------
+
+#deadlock_timeout = 1s
+#max_locks_per_transaction = 64         # min 10
+                                        # (change requires restart)
+# Note:  Each lock table slot uses ~270 bytes of shared memory, and there are
+# max_locks_per_transaction * (max_connections + max_prepared_transactions)
+# lock table slots.
+
+
+#------------------------------------------------------------------------------
+# VERSION/PLATFORM COMPATIBILITY
+#------------------------------------------------------------------------------
+
+# - Previous PostgreSQL Versions -
+
+#array_nulls = on
+#backslash_quote = safe_encoding        # on, off, or safe_encoding
+#default_with_oids = off
+#escape_string_warning = on
+#lo_compat_privileges = off
+#sql_inheritance = on
+#standard_conforming_strings = off
+#synchronize_seqscans = on
+
+# - Other Platforms and Clients -
+
+#transform_null_equals = off
+
+
+#------------------------------------------------------------------------------
+# CUSTOMIZED OPTIONS
+#------------------------------------------------------------------------------
+
+#custom_variable_classes = ''           # list of custom variable class names
+include '<%= @postgres_root %>/<%= @postgres_version %>/custom.conf'


### PR DESCRIPTION
Description of your patch
-------------
Fix Replication for PostgreSQL 12 and above

Recommended Release Notes
-------------
Fix Replication for PostgreSQL 12 and above

Estimated risk
-------------
High

Components involved
-------------
Clients using PostgreSQL 12 and above

Description of testing done
-------------
* Create v7 environment (without booting instances)
* Add `EY_POSTGRES_VERSION` as environment variable and set value to 12, 13 or 14
* Upload the updated `ey-postgres` recipe
* Boot the environment with a DB Slave
* Verify if the chef run is successful
* Confirm that the replication is working

QA Instructions
-------------
* Create v7 environment (without booting instances)
* Add `EY_POSTGRES_VERSION` as environment variable and set value to 12, 13 or 14
* Upload the updated `ey-postgres` recipe
* Boot the environment with a DB Slave
* Verify if the chef run is successful
* Confirm that the replication is working