### PR TITLE
[FBZ-10517] Fix postgresql.conf for PostgreSQL 9.5 and 9.6 in v7

### DIFF
--- a/cookbooks/ey-postgresql/templates/default/postgresql.conf.erb
+++ b/cookbooks/ey-postgresql/templates/default/postgresql.conf.erb
@@ -193,7 +193,7 @@ max_wal_senders = 5		# max number of walsender processes
 #wal_sender_delay = 200ms	# walsender cycle time, 1-10000 milliseconds
 
 # as per chnage in postgres version 13 `wal_keep_segments` is renamed to `wal_keep_size` https://pgpedia.info/w/wal_keep_segments.html
-<% if @postgres_version >= "13.0" %>
+<% if postgres_version_gte?("13") %>
 wal_keep_size = 2048 # in logfile segments, 16MB each; 0 disables 
 <% else %>
 wal_keep_segments = 128 		# in logfile segments, 16MB each; 0 disables


### PR DESCRIPTION
Description of your patch
-------------
Fix postgresql.conf for PostgreSQL 9.5 and 9.6 in v7

Recommended Release Notes
-------------
Fix postgresql.conf for PostgreSQL 9.5 and 9.6 in v7 - [#156](https://github.com/engineyard/ey-cookbooks-stable-v7/issues/156)

Estimated risk
-------------
High

Components involved
-------------
Clients using PostgreSQL 9.5 and 9.6 in v7

Dependencies
-------------

Description of testing done
-------------
**For PostgreSQL 9.5 and 9.6:**
* Create v7 environment with PostgreSQL 9.5 or 9.6 as DB
* Verify if chef run is successful
* If failed, check the error if it is pointing to `"wal_keep_size" in file "/db/postgresql/<postgres version>/data/postgresql.conf" line 189`
* If confirmed, upload the updated recipe to the environment and trigger chef run again
* Verify if chef run is successful
* Execute `systemctl restart postgresql.service`, confirm that the previous issue was resolved

**For PostgreSQL 13 and above:**
* Create v7 environment with PostgreSQL as DB (don't boot yet)
* Add Environment Variable `EY_POSTGRES_VERSION` and set the value to 13 or above
* Upload the updated recipe to the environment
* Boot the environment
* Verify if chef run is successful
* Execute `systemctl restart postgresql.service`, confirm that there are no issues

QA Instructions
-------------
**For PostgreSQL 9.5 and 9.6:**
* Create v7 environment with PostgreSQL 9.5 or 9.6 as DB
* Verify if chef run is successful
* If failed, check the error if it is pointing to `"wal_keep_size" in file "/db/postgresql/<postgres version>/data/postgresql.conf" line 189`
* If confirmed, upload the updated recipe to the environment and trigger chef run again
* Verify if chef run is successful
* Execute `systemctl restart postgresql.service`, confirm that the previous issue was resolved

**For PostgreSQL 13 and above:**
* Create v7 environment with PostgreSQL as DB (don't boot yet)
* Add Environment Variable `EY_POSTGRES_VERSION` and set the value to 13 or above
* Upload the updated recipe to the environment
* Boot the environment
* Verify if chef run is successful
* Execute `systemctl restart postgresql.service`, confirm that there are no issues