### PR TITLE
[FBZ-10519] Fix alerts prompting out during collectd nanny daily

### DIFF
--- a/cookbooks/ey-collectd/files/default/collectd_nanny
+++ b/cookbooks/ey-collectd/files/default/collectd_nanny
@@ -11,7 +11,7 @@ then
   #echo "Resetting collectd based on daily schedule"
   # inittab will reset automatically
   # killall -9 collectd
-  #echo "skipped daily collectd nanny process!"
+  echo "skipped daily collectd nanny process!"
 else
   #echo "Cancelling child processes running longer than 1 hour..."
   ps -eo pid,ppid,etime,cmd|grep '/usr/sbin/[c]ollectd'|awk '{print $1" "$2" "$3}' | while read -r p

--- a/cookbooks/ey-collectd/files/default/collectd_nanny
+++ b/cookbooks/ey-collectd/files/default/collectd_nanny
@@ -10,8 +10,8 @@ if [[ $1 == 'daily' ]]
 then
   #echo "Resetting collectd based on daily schedule"
   # inittab will reset automatically
-  killall -9 collectd
-  #echo "done!"
+  # killall -9 collectd
+  #echo "skipped daily collectd nanny process!"
 else
   #echo "Cancelling child processes running longer than 1 hour..."
   ps -eo pid,ppid,etime,cmd|grep '/usr/sbin/[c]ollectd'|awk '{print $1" "$2" "$3}' | while read -r p


### PR DESCRIPTION
Description of your patch
-------------
Fixed sending of multiple collected alerts on v7 environments during collectd process restart.

Recommended Release Notes
-------------
Fixed sending of multiple collected alerts on v7 environments during collectd process restart.  This addresses issue #159.

Estimated risk
-------------
Medium

Components involved
-------------
`ey-collectd`

Dependencies
-------------
`ey-collectd`

Description of testing done
-------------
1. Overlay the recipes
2. Trigger `/engineyard/bin/collectd_nanny daily` and see if alerts are reflected

QA Instructions
-------------
1. Overlay the recipes
2. Trigger `/engineyard/bin/collectd_nanny daily` and see if alerts are reflected

_tc1_
* Download a large file which could reach warning limits
* Download a large file which could reach failure limits

_tc2_
* Do load testing and see if alerts appear and recover as per [this article](https://bigomega.medium.com/simple-load-testing-script-in-bash-a8c5a4968dc7)

_tc3_
* Stop the mysql service and see if alert appears
* Stop the postgresql service and see if alert appears 
* Do the vise-versa too

_tc4_
* Boot a multi psql master-slave config
* Stop the slave and see if alerts appear