### PR TITLE
[FBZ-10521] EYDR Duplicate Replication Fix

### DIFF
--- a/custom-cookbooks/eydr/cookbooks/eydr/libraries/helpers.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/libraries/helpers.rb
@@ -1,0 +1,18 @@
+module PostgreSQL
+  module Helper
+    def pg_eydr_replicating_from_master
+      `psql -U postgres -c "select conninfo from pg_stat_wal_receiver;" | grep host=127.0.0.1 | awk '{print $5}'`.strip == "host=127.0.0.1"
+    end
+
+    def pg_eydr_streaming
+      `psql -U postgres -c "select status from pg_stat_wal_receiver;" | grep streaming | awk '{print $NF}'`.strip == "streaming"
+    end
+
+    def pg_in_recovery
+      `psql -U postgres -c "select pg_is_in_recovery();" | grep t | awk '{print $NF}'`.strip == "t"
+    end
+  end
+end
+
+Chef::DSL::Recipe.send(:include, PostgreSQL::Helper)
+Chef::Resource.send(:include, PostgreSQL::Helper)

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_replication.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_replication.rb
@@ -96,13 +96,12 @@ if node["establish_replication"]
     timeout 7200  # default 2 hours, if you have a lot of data you may need to increase this
     action :nothing
   end
-end
-
-if node["establish_replication"]
-  execute "check-replication" do
-    command "echo 'Replication is set to true.\nExecute setup-replication if no replication is ongoing'"
-    notifies :run, 'execute[setup-replication]', :immediately
-    not_if "psql -U postgres -c'select conninfo from pg_stat_wal_receiver;' | grep host=127.0.0.1 && psql -U postgres -c'select status from pg_stat_wal_receiver;' | grep streaming"
-  end
+  
+  if !pg_eydr_replicating_from_master && !pg_eydr_streaming && !pg_in_recovery
+    execute "check-replication" do
+      command "echo 'Replication is set to true.\nExecute setup-replication bash if no replication is ongoing'"
+      notifies :run, 'execute[setup-replication]', :immediately
+    end
+  end 
 end
 

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_replication.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_replication.rb
@@ -70,7 +70,7 @@ if postgres_version_gte?("15")
       slave_public_hostname: node["dr_replication"][node["dna"]["environment"]["framework_env"]]["slave"]["public_hostname"],
       version: node["postgresql"]["short_version"]
     )
-    not_if { ::File.exist?('/engineyard/bin/setup_replication.sh') }
+    action :create_if_missing
   end
 else
   # Render the script to setup replication
@@ -85,7 +85,7 @@ else
       slave_public_hostname: node["dr_replication"][node["dna"]["environment"]["framework_env"]]["slave"]["public_hostname"],
       version: node["postgresql"]["short_version"]
     )
-    not_if { ::File.exist?('/engineyard/bin/setup_replication.sh') }
+    action :create_if_missing
   end
 end
 
@@ -96,12 +96,12 @@ if node["establish_replication"]
     timeout 7200  # default 2 hours, if you have a lot of data you may need to increase this
     action :nothing
   end
-  
+
   if !pg_eydr_replicating_from_master && !pg_eydr_streaming && !pg_in_recovery
     execute "check-replication" do
       command "echo 'Replication is set to true.\nExecute setup-replication bash if no replication is ongoing'"
-      notifies :run, 'execute[setup-replication]', :immediately
+      notifies :run, "execute[setup-replication]", :immediately
     end
-  end 
+  end
 end
 


### PR DESCRIPTION
Description of your patch
-------------
Fixed issue with duplication replication for eydr

Recommended Release Notes
-------------
Fixed issue with duplication replication for eydr

Estimated risk
-------------
Low

Components involved
-------------
Clients using eydr recipe

Dependencies
-------------
`eydr`

Description of testing done
-------------
* Create 2 v7 stack environments on different regions
* Upload custom recipe eydr with the modified details for Master env and Slave env
* Do pre-requisites available in https://github.com/engineyard/ey-cookbooks-stable-v7/blob/next-release/custom-cookbooks/eydr/cookbooks/eydr/README.md
* Test replication via modifying `eydr/attributues/replication.rb`, setting `establish_replication` to `true`
* Upload and apply
* On the chef logs, confirm that `check-replication` was executed
* Confirm that the replication is working by logging into PostgreSQL and executing `select * from pg_stat_wal_receiver;`
* Trigger a chef run again and confirm that `check-replication` was not executed as the replication is already configured

QA Instructions
-------------
* Create 2 v7 stack environments on different regions
* Upload custom recipe eydr with the modified details for Master env and Slave env
* Do pre-requisites available in https://github.com/engineyard/ey-cookbooks-stable-v7/blob/next-release/custom-cookbooks/eydr/cookbooks/eydr/README.md
* Test replication via modifying `eydr/attributues/replication.rb`, setting `establish_replication` to `true`
* Upload and apply
* On the chef logs, confirm that `check-replication` was executed
* Confirm that the replication is working by logging into PostgreSQL and executing `select * from pg_stat_wal_receiver;`
* Trigger a chef run again and confirm that `check-replication` was not executed as the replication is already configured