### PR TITLE
[FBZ-10521] Fix setup-replication block

### DIFF
--- a/custom-cookbooks/eydr/cookbooks/eydr/libraries/helpers.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/libraries/helpers.rb
@@ -7,10 +7,6 @@ module PostgreSQL
     def pg_eydr_streaming
       `psql -U postgres -c "select status from pg_stat_wal_receiver;" | grep streaming | awk '{print $NF}'`.strip == "streaming"
     end
-
-    def pg_in_recovery
-      `psql -U postgres -c "select pg_is_in_recovery();" | grep t | awk '{print $NF}'`.strip == "t"
-    end
   end
 end
 

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_replication.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_replication.rb
@@ -91,7 +91,7 @@ end
 
 # Only run the setup replication script if the enable_replication flag is set to true in the attributes
 if node["establish_replication"]
-  bash "setup-replication" do
+  execute "setup-replication" do
     code "/engineyard/bin/setup_replication.sh"
     timeout 7200  # default 2 hours, if you have a lot of data you may need to increase this
     action :nothing

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_replication.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_replication.rb
@@ -97,7 +97,7 @@ if node["establish_replication"]
     action :nothing
   end
 
-  if !pg_eydr_replicating_from_master && !pg_eydr_streaming && !pg_in_recovery
+  if !pg_eydr_replicating_from_master && !pg_eydr_streaming
     execute "check-replication" do
       command "echo 'Replication is set to true.\nExecute setup-replication bash if no replication is ongoing'"
       notifies :run, "execute[setup-replication]", :immediately

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_replication.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_replication.rb
@@ -92,7 +92,7 @@ end
 # Only run the setup replication script if the enable_replication flag is set to true in the attributes
 if node["establish_replication"]
   execute "setup-replication" do
-    code "/engineyard/bin/setup_replication.sh"
+    command "/engineyard/bin/setup_replication.sh"
     timeout 7200  # default 2 hours, if you have a lot of data you may need to increase this
     action :nothing
   end


### PR DESCRIPTION
Description of your patch
-------------
 Fix EYDR replication issue

Recommended Release Notes
-------------
 Fix EYDR replication issue

Estimated risk
-------------
Low

Components involved
-------------
Client that use eydr

Dependencies
-------------
eydr

Description of testing done
-------------
* Create 2 v7 stack environments on different regions
* Upload custom recipe eydr with the modified details for Master env and Slave env
* Do pre-requisites available in https://github.com/engineyard/ey-cookbooks-stable-v7/blob/next-release/custom-cookbooks/eydr/cookbooks/eydr/README.md
* Test replication via modifying `eydr/attributues/replication.rb`, setting `establish_replication` to true
* Upload and apply
* On the chef logs, confirm that check-replication was executed
* Confirm that the replication is working by logging into PostgreSQL and executing `select * from pg_stat_wal_receiver;`
* Trigger a chef run again and confirm that `check-replication` was not executed as the replication is already configured

QA Instructions
-------------
* Create 2 v7 stack environments on different regions
* Upload custom recipe eydr with the modified details for Master env and Slave env
* Do pre-requisites available in https://github.com/engineyard/ey-cookbooks-stable-v7/blob/next-release/custom-cookbooks/eydr/cookbooks/eydr/README.md
* Test replication via modifying `eydr/attributues/replication.rb`, setting `establish_replication` to true
* Upload and apply
* On the chef logs, confirm that check-replication was executed
* Confirm that the replication is working by logging into PostgreSQL and executing `select * from pg_stat_wal_receiver;`
* Trigger a chef run again and confirm that `check-replication` was not executed as the replication is already configured