### PR TITLE
[FBZ-10531] Fix ClamAV cronjob not running issue

### DIFF
--- a/cookbooks/ey-clamav/README.md
+++ b/cookbooks/ey-clamav/README.md
@@ -11,3 +11,8 @@ In order to implement clamav on your environment.
 * `EY_CLAMAV_SOLO_PATHS`
 
 default value for each of the roles would be `[]` , In order add paths to run under the scanner, set the value to an Array like `["/data", "/tmp"]` which would create 2 cronjobs to run.
+
+3. In order to configure times
+
+* EY_CLAMAV_RUNHOUR - Integer - The hour to configure the cron to run at every day
+* EY_CLAMAV_RUNMINUTE - Integet - The Minute to configure the cron to run at the mentioned hour every day

--- a/cookbooks/ey-clamav/README.md
+++ b/cookbooks/ey-clamav/README.md
@@ -15,4 +15,4 @@ default value for each of the roles would be `[]` , In order add paths to run un
 3. In order to configure times
 
 * EY_CLAMAV_RUNHOUR - Integer - The hour to configure the cron to run at every day
-* EY_CLAMAV_RUNMINUTE - Integet - The Minute to configure the cron to run at the mentioned hour every day
+* EY_CLAMAV_RUNMINUTE - Integer - The Minute to configure the cron to run at the mentioned hour every day

--- a/cookbooks/ey-clamav/attributes/default.rb
+++ b/cookbooks/ey-clamav/attributes/default.rb
@@ -22,3 +22,5 @@ default["clamav"]["scanpath_solo"] = get_path_array(fetch_env_var(node, "EY_CLAM
 
 default["clamav"]["autoremove_infected"] = fetch_env_var(node, "EY_CLAMAV_AUTOREMOVE_INFECTED", false)
 default["clamav"]["quarantine_directory"] = "/mnt/quarantine"
+default["clamav"]["runhour"] = fetch_env_var(node, "EY_CLAMAV_RUNHOUR", 5)
+default["clamav"]["runminute"] = fetch_env_var(node, "EY_CLAMAV_RUNMINUTE", 0)

--- a/cookbooks/ey-clamav/recipes/configure.rb
+++ b/cookbooks/ey-clamav/recipes/configure.rb
@@ -1,5 +1,7 @@
 clamav = node["clamav"]
 autoremove_infected = clamav["autoremove_infected"]
+clamav_run_hour = clamav["runhour"]
+clamav_run_minute = clamav["runminute"]
 $quarantine_directory = clamav["quarantine_directory"]
 
 directory $quarantine_directory do
@@ -12,7 +14,10 @@ cron "update clamav knowledgebase" do
   user "root"
 end
 
-def clamav_scan_cron(scanpath, autorm_infected = true)
+def clamav_scan_cron(scanpath, autorm_infected = true, runhour = 5, runminute = 0)
+  runhour_count = 0
+  run_hour = runhour
+  run_minute = runminute
   scanpath.each { |path|
     command = "clamscan --recursive " + path
     cron_name = node["dna"]["instance_role"] + " clamav cron for " + path
@@ -22,10 +27,20 @@ def clamav_scan_cron(scanpath, autorm_infected = true)
       command << " --move #{$quarantine_directory}"
     end
     cron cron_name do
-      minute 0
-      hour 5
-      command command + " >> /var/log/clamav/clamav-$(date +'%Y%m%d')"
+      minute runminute
+      hour runhour
+      command command + " >> /var/log/clamav/clamav"
       user "root"
+    end
+
+    runhour_count += 1
+    if runhour_count >= 3
+      run_hour += 1
+    end
+
+    run_minute += 20
+    if run_minute >= 60
+      run_minute = 0
     end
   }
 end

--- a/cookbooks/ey-clamav/recipes/configure.rb
+++ b/cookbooks/ey-clamav/recipes/configure.rb
@@ -27,8 +27,6 @@ def clamav_scan_cron(scanpath, autorm_infected = true, runhour = 5, runminute = 
       user "root"
     end
 
-    runhour_count += 1
-
     run_minute += 20
     if run_minute >= 60
       run_minute = 0


### PR DESCRIPTION
Description of your patch
-------------
Fix issue with ClamAV cronjob not running successfully

Recommended Release Notes
-------------
Fix ClamAV cronjobs not running issue.
Fixes issue with multiple ClamAV cronjobs running at the same time resulting in high load.
Feature added to amend the cronjob schedule via environment variables.

Estimated risk
-------------
Normal

Components involved
-------------
ey-clamav

Dependencies
-------------
ey-base

Description of testing done
-------------
1. Boot a new environment under v7.
2. Enable `EY_CLAMAV_ENABLED` to `true`
3. Set multiple scan routes/paths via `EY_CLAMAV_SOLO` or with another relevant variables for the environment.
4. Set `EY_CLAMAV_RUNHOUR` to a desired value from 0-23
5. Set `EY_CLAMAV_RUNMINUTE` to a desired value from 0 to 59


QA Instructions
-------------
1. Boot a new environment under v7.
2. Enable `EY_CLAMAV_ENABLED` to `true`
3. Set multiple scan routes/paths via `EY_CLAMAV_SOLO` or with another relevant variables for the environment.
4. Set `EY_CLAMAV_RUNHOUR` to a desired value from 0-23
5. Set `EY_CLAMAV_RUNMINUTE` to a desired value from 0 to 59