### PR TITLE
[FBZ-10532] MySQL Slave-relay log removed by chef

### DIFF
--- a/cookbooks/ey-mysql/resources/mysql_slave.rb
+++ b/cookbooks/ey-mysql/resources/mysql_slave.rb
@@ -113,7 +113,7 @@ action :action_mysql_slave do
   execute "remove slave-relay*" do
     cwd node["mysql"]["datadir"]
     command "rm -f #{node['mysql']['datadir']}/slave-relay*"
-    only_if { !Dir.glob("#{node['mysql']['datadir']}/slave-relay*").empty? && !volume_from_slave_snapshot }
+    only_if { !Dir.glob("#{node['mysql']['datadir']}/slave-relay*").empty? && !volume_from_slave_snapshot  && !mysql_slave_is_slavey? }
   end
 
   # the master writes it's uuid to <datadir>/auto.cnf, the slave needs that removed so it will gen it's own


### PR DESCRIPTION
### Description of your patch
Fix MySQL slave replication failure due to slave-relay log removal. 

### Recommended Release Notes

Fix MySQL slave replication failure due to slave-relay log removal. 

### Estimated risk
High

### Description of testing done

- Create a v7 environment with MySQL 5.7 as DB
- Boot environment with one DB master and one DB slave.
- upload overlay recipe for ey-mysql with fix in this PR 
- Apply 
- check for slave-relay log files under `ls -lah /db/mysql/5.7/data/|grep slave `

### QA Instructions
- Create a v7 environment with MySQL 5.7 as DB
- Boot environment with one DB master and one DB slave.
- upload overlay recipe for ey-mysql with fix in this PR 
- Apply 
- check for slave-relay log files under `ls -lah /db/mysql/5.7/data/|grep slave `