### PR TITLE
[fbz-10529] Add status reporting on recipes

### DIFF
--- a/cookbooks/ey-haproxy/recipes/default.rb
+++ b/cookbooks/ey-haproxy/recipes/default.rb
@@ -1,6 +1,10 @@
 ey_cloud_report "haproxy" do
-  message "processing haproxy"
+  message "processing haproxy started"
 end
 
 include_recipe "ey-haproxy::configure"
 include_recipe "ey-haproxy::install"
+
+ey_cloud_report "haproxy" do
+  message "processing haproxy finished"
+end

--- a/cookbooks/ey-nginx/recipes/install.rb
+++ b/cookbooks/ey-nginx/recipes/install.rb
@@ -1,5 +1,5 @@
 ey_cloud_report "nginx" do
-  message "processing nginx"
+  message "processing nginx started"
 end
 
 # Mask nginx on non-app instances
@@ -63,4 +63,8 @@ logrotate "nginx" do
   restart_command <<-SH
 [ ! -f /var/run/nginx.pid ] || kill -USR1 `cat /var/run/nginx.pid`
   SH
+end
+
+ey_cloud_report "nginx" do
+  message "processing nginx finished"
 end

--- a/cookbooks/ey-passenger5/recipes/install.rb
+++ b/cookbooks/ey-passenger5/recipes/install.rb
@@ -7,7 +7,7 @@ recipe = self
 
 # Notify dashboard
 ey_cloud_report "passenger5" do
-  message "Processing Passenger 5"
+  message "Installing Passenger 5 started"
 end
 
 # Install gems required by Passenger standalone
@@ -94,4 +94,8 @@ cookbook_file "/engineyard/bin/passenger_monitor" do
   group node["owner_name"]
   mode "0655"
   backup 0
+end
+
+ey_cloud_report "passenger5" do
+  message "Installing Passenger 5 finished"
 end

--- a/cookbooks/ey-puma/recipes/default.rb
+++ b/cookbooks/ey-puma/recipes/default.rb
@@ -1,5 +1,5 @@
 ey_cloud_report "puma" do
-  message "processing puma"
+  message "processing puma started"
 end
 
 workers = [(1.0 * get_pool_size() / node["dna"]["applications"].size).round, 1].max
@@ -105,4 +105,8 @@ node.engineyard.apps.each_with_index do |app, index|
               username: ssh_username)
     notifies :run, "execute[reload-systemd]"
   end
+end
+
+ey_cloud_report "puma" do
+  message "processing puma finished"
 end

--- a/cookbooks/ey-unicorn/recipes/setup.rb
+++ b/cookbooks/ey-unicorn/recipes/setup.rb
@@ -1,5 +1,5 @@
 ey_cloud_report "ey-unicorn" do
-  message "processing unicorn"
+  message "processing unicorn started"
 end
 
 directory "/var/log/engineyard/unicorn" do
@@ -22,4 +22,8 @@ node.engineyard.apps.each do |app|
     mode "755"
     recursive true
   end
+end
+
+ey_cloud_report 'ey-unicorn' do
+    message 'processing unicorn finished'
 end


### PR DESCRIPTION
Description of your patch
-------------
Adds more cloud reports during chef run


Recommended Release Notes
-------------
Feature added to provide more chef status reports on v7

Estimated risk
-------------
Normal

Components involved
-------------
ey-puma 
ey-nginx 
ey-unicorn 
ey-passenger5 
ey-haproxy

Dependencies
-------------
ey-lib

Description of testing done
-------------
1.) Boot 3 new environments under v7
2.) During chef run, check the report under instance from the UI

QA Instructions
-------------
1.) Boot 3 new environments under v7
 2.) Each environment with different App server - Puma, Unicorn and Passenger 
3.) During chef run, check the report under instance from the UI

