### PR TITLE
[FBZ-10531] Fix Schedul casting issues based on Hour and Minutes

### DIFF
--- a/cookbooks/ey-clamav/recipes/configure.rb
+++ b/cookbooks/ey-clamav/recipes/configure.rb
@@ -1,7 +1,7 @@
 clamav = node["clamav"]
 autoremove_infected = clamav["autoremove_infected"]
-clamav_run_hour = clamav["runhour"]
-clamav_run_minute = clamav["runminute"]
+clamav_run_hour = clamav["runhour"].to_i
+clamav_run_minute = clamav["runminute"].to_i
 $quarantine_directory = clamav["quarantine_directory"]
 
 directory $quarantine_directory do


### PR DESCRIPTION
Description of your patch
-------------
Fix issue with ClamAV cronjob not scheduling as per the environment-variable inputs.

Recommended Release Notes
-------------
Feature added to amend the cronjob schedule via environment variables.

Estimated risk
-------------
Normal

Components involved
-------------
ey-clamav

Dependencies
-------------
ey-base

Description of testing done
-------------
1. Boot a new environment under v7.
2. Enable `EY_CLAMAV_ENABLED` to `true`
3. Set multiple scan routes/paths via `EY_CLAMAV_SOLO_PATHS` or with another relevant variables for the environment.
4. Set `EY_CLAMAV_RUNHOUR` to a desired value from 0-23
5. Set `EY_CLAMAV_RUNMINUTE` to a desired value from 0 to 59


QA Instructions
-------------
1. Boot a new environment under v7.
2. Enable `EY_CLAMAV_ENABLED` to `true`
3. Set multiple scan routes/paths via `EY_CLAMAV_SOLO_PATHS` or with another relevant variables for the environment.
4. Set `EY_CLAMAV_RUNHOUR` to a desired value from 0-23
5. Set `EY_CLAMAV_RUNMINUTE` to a desired value from 0 to 59