### PR TITLE
[FBZ-10514] Fix MySQL 8 on v7

### DIFF
--- a/cookbooks/ey-mysql/recipes/install.rb
+++ b/cookbooks/ey-mysql/recipes/install.rb
@@ -95,11 +95,11 @@ packages.each do |package|
     only_if { node.engineyard.instance.arch_type == "amd64" }
   end
 end
-if node["mysql"]["short_version"] == "8.0"
-  bash "Set my.cnf alternatives for MySQL 8.0" do
-    code <<-EOS
+if node["dna"]["instance_role"][/^(db|solo)/] && node["mysql"]["short_version"] == "8.0"
+ bash "Set my.cnf alternatives for MySQL 8.0" do
+  code <<-EOS
   update-alternatives --install /etc/mysql/my.cnf my.cnf /etc/mysql/percona-server.cnf 1000
   update-alternatives --set my.cnf /etc/mysql/percona-server.cnf
   EOS
-  end
+ end
 end

--- a/cookbooks/ey-mysql/recipes/install.rb
+++ b/cookbooks/ey-mysql/recipes/install.rb
@@ -96,10 +96,10 @@ packages.each do |package|
   end
 end
 if node["mysql"]["short_version"] == "8.0"
- bash "Set my.cnf alternatives for MySQL 8.0" do
-  code <<-EOS
+  bash "Set my.cnf alternatives for MySQL 8.0" do
+    code <<-EOS
   update-alternatives --install /etc/mysql/my.cnf my.cnf /etc/mysql/percona-server.cnf 1000
   update-alternatives --set my.cnf /etc/mysql/percona-server.cnf
   EOS
- end
+  end
 end

--- a/cookbooks/ey-mysql/recipes/install.rb
+++ b/cookbooks/ey-mysql/recipes/install.rb
@@ -96,10 +96,10 @@ packages.each do |package|
   end
 end
 if node["dna"]["instance_role"][/^(db|solo)/] && node["mysql"]["short_version"] == "8.0"
- bash "Set my.cnf alternatives for MySQL 8.0" do
-  code <<-EOS
+  bash "Set my.cnf alternatives for MySQL 8.0" do
+    code <<-EOS
   update-alternatives --install /etc/mysql/my.cnf my.cnf /etc/mysql/percona-server.cnf 1000
   update-alternatives --set my.cnf /etc/mysql/percona-server.cnf
   EOS
- end
+  end
 end

--- a/cookbooks/ey-mysql/recipes/install.rb
+++ b/cookbooks/ey-mysql/recipes/install.rb
@@ -95,3 +95,11 @@ packages.each do |package|
     only_if { node.engineyard.instance.arch_type == "amd64" }
   end
 end
+if node["mysql"]["short_version"] == "8.0"
+ bash "Set my.cnf alternatives for MySQL 8.0" do
+  code <<-EOS
+  update-alternatives --install /etc/mysql/my.cnf my.cnf /etc/mysql/percona-server.cnf 1000
+  update-alternatives --set my.cnf /etc/mysql/percona-server.cnf
+  EOS
+ end
+end

--- a/cookbooks/ey-mysql/recipes/startup.rb
+++ b/cookbooks/ey-mysql/recipes/startup.rb
@@ -25,3 +25,10 @@ service "mysql" do
   provider Chef::Provider::Service::Systemd
   action :enable
 end
+
+if node["mysql"]["short_version"] == "8.0"
+  service "mysql" do
+  action :restart
+  not_if { ::File.exist?('/db/mysql/8.0/data/mysql.ibd') }
+ end
+end

--- a/cookbooks/ey-mysql/recipes/startup.rb
+++ b/cookbooks/ey-mysql/recipes/startup.rb
@@ -28,7 +28,7 @@ end
 
 if node["mysql"]["short_version"] == "8.0"
   service "mysql" do
-  action :restart
-  not_if { ::File.exist?('/db/mysql/8.0/data/mysql.ibd') }
- end
+    action :restart
+    not_if { ::File.exist?("/db/mysql/8.0/data/mysql.ibd") }
+  end
 end

--- a/cookbooks/ey-mysql/resources/mysql_slave.rb
+++ b/cookbooks/ey-mysql/resources/mysql_slave.rb
@@ -17,14 +17,14 @@ action :action_mysql_slave do
     command "echo"
   end
 
- def self.mysql_slave_is_slavey?
-   begin
-     foo = `mysql -e "show slave status"`
-     !foo.empty?
-   rescue
-     false
-   end
- end
+  def self.mysql_slave_is_slavey?
+    begin
+      foo = `mysql -e "show slave status"`
+      !foo.empty?
+    rescue
+      false
+    end
+  end
 
   ruby_block "clean up half-done install" do
     block do
@@ -113,7 +113,7 @@ action :action_mysql_slave do
   execute "remove slave-relay*" do
     cwd node["mysql"]["datadir"]
     command "rm -f #{node['mysql']['datadir']}/slave-relay*"
-    only_if { !Dir.glob("#{node['mysql']['datadir']}/slave-relay*").empty? && !volume_from_slave_snapshot  && !mysql_slave_is_slavey? }
+    only_if { !Dir.glob("#{node['mysql']['datadir']}/slave-relay*").empty? && !volume_from_slave_snapshot && !mysql_slave_is_slavey? }
   end
 
   # the master writes it's uuid to <datadir>/auto.cnf, the slave needs that removed so it will gen it's own


### PR DESCRIPTION
### Description of your patch
Fixed MySQL 8 running with default configurations on v7. 

### Recommended Release Notes
Fixed issue where MySQL 8 on v7 was running for EY DB configurations. 

### Estimated risk
High

### Components involved
All clients who use MySQL8 on stack v7.

### Dependencies
ey-mysql

### Description of testing done

Created 3 v7 environments with MySQL:

**1. Solo MySQL 8 env:**

* Environment on latest v7 DB as MySQL 8 with overly recipes uploaded.
* Boot Environment.
* Log in to instance and run `lsof|grep mysql` to see if its is running under /db or /var/lib/mysql. Correct path should be under /db/mysql.
* Run `/etc/init.d/mysql status` and note running time, now Apply again and note service active time to see if restart mysql. It should not. 

**2. cluster MySQL 8 env(DB master and DB slave):**

* Environment on latest v7 DB as MySQL 8 with overly recipes uploaded.
* Boot Environment.
* Log in to DB master  and DB slave instances and run `lsof|grep mysql` to see if its is running under /db or /var/lib/mysql. Correct path should be under /db/mysql.
* SSh to Slave DB instance and see `Show slave status\G;`, replication should be running. 
* Run `/etc/init.d/mysql status` and note running time, now Apply again and note service active time to see if restart mysql. It should not.

**3. cluster MySQL 5.7 env(DB master and DB slave):**

* Environment on latest v7 DB as MySQL 5.7 with overly recipes uploaded.
* Boot Environment.
* Log in to DB master  and DB slave instances and run `lsof|grep mysql` to see if its is running under /db or /var/lib/mysql. Correct path should be under /db/mysql.
* SSh to Slave DB instance and see `Show slave status\G;`, replication should be running. 
* Run `/etc/init.d/mysql status` and note running time, now Apply again and note service active time to see if restart mysql. It should not.

### QA Instructions

Create 3 v7 environments with MySQL:

**1. Solo MySQL 8 env:**

* Environment on latest v7 DB as MySQL 8 with overly recipes uploaded.
* Boot Environment.
* Log in to instance and run `lsof|grep mysql` to see if its is running under /db or /var/lib/mysql. Correct path should be under /db/mysql.
* Run `/etc/init.d/mysql status` and note running time, now Apply again and note service active time to see if restart mysql. It should not. 

**2. cluster MySQL 8 env(DB master and DB slave):**

* Environment on latest v7 DB as MySQL 8 with overly recipes uploaded.
* Boot Environment.
* Log in to DB master  and DB slave instances and run `lsof|grep mysql` to see if its is running under /db or /var/lib/mysql. Correct path should be under /db/mysql.
* SSh to Slave DB instance and see `Show slave status\G;`, replication should be running. 
* Run `/etc/init.d/mysql status` and note running time, now Apply again and note service active time to see if restart mysql. It should not.

**3. cluster MySQL 5.7 env(DB master and DB slave):**

* Environment on latest v7 DB as MySQL 5.7 with overly recipes uploaded.
* Boot Environment.
* Log in to DB master  and DB slave instances and run `lsof|grep mysql` to see if its is running under /db or /var/lib/mysql. Correct path should be under /db/mysql.
* SSh to Slave DB instance and see `Show slave status\G;`, replication should be running. 
* Run `/etc/init.d/mysql status` and note running time, now Apply again and note service active time to see if restart mysql. It should not.