### PR TITLE
[FBZ-10539] - Remove trigger file if replication is reenabled

### DIFF
--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_replication.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_replication.rb
@@ -48,6 +48,11 @@ else
   end
 end
 
+bash "remove-trigger-file" do
+    code "rm /tmp/postgresql.trigger"
+      only_if { ::File.exist?("/tmp/postgresql.trigger") }
+end
+
 # Ensure the wal directory exists
 directory "/db/postgresql/#{node['postgresql']['short_version']}/wal/" do
   owner "postgres"

--- a/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_replication.rb
+++ b/custom-cookbooks/eydr/cookbooks/eydr/recipes/postgres_replication.rb
@@ -49,8 +49,8 @@ else
 end
 
 bash "remove-trigger-file" do
-    code "rm /tmp/postgresql.trigger"
-      only_if { ::File.exist?("/tmp/postgresql.trigger") }
+  code "rm /tmp/postgresql.trigger"
+  only_if { ::File.exist?("/tmp/postgresql.trigger") }
 end
 
 # Ensure the wal directory exists


### PR DESCRIPTION
Description of your patch
-------------
Remove trigger file if replication is reenabled

Recommended Release Notes
-------------
Updated EYDR Recipe to remove trigger file if replication is re-enabled on the slave environment

Estimated risk
-------------
Low

Components involved
-------------
Clients who use eydr recipe

Dependencies
-------------
N/A

Description of testing done
-------------
* Boot v7 environment on **N. Virginia region** with PostegreSQL 14.5 (Master environment)
* Boot v7 environment on **any other region except N. Virginia** with PostgreSQL 14.5 (Slave environment)
* Do the pre-requisites for EYDR configuration (Refer to the readme file)
* Upload and apply the EYDR recipe with `default["establish_replication"]` set to true
* Verify that the slave environment is replicating by logging into the slave environment's DB and executing `select * from pg_stat_wal_receiver;` via postgres
* Update the EYDR configuration by setting `default["establish_replication"]` to false and `default["failover"]` to true, upload and apply
* Verify that the slave environment is **not** replicating by logging into the slave environment's DB and executing `select * from pg_stat_wal_receiver;` via postgres
* Verify that the file `/tmp/postgresql.trigger` has been created on slave environment's DB
* Update the EYDR configuration by setting `default["establish_replication"]` to true and `default["failover"]` to false, upload and apply
* Verify that the slave environment is replicating **again** by logging into the slave environment's DB and executing `select * from pg_stat_wal_receiver;` via postgres
* Verify that the file `/tmp/postgresql.trigger` is no longer on slave environment's DB

QA Instructions
-------------
* Boot v7 environment on **N. Virginia region** with PostegreSQL 14.5 (Master environment)
* Boot v7 environment on **any other region except N. Virginia** with PostgreSQL 14.5 (Slave environment)
* Do the pre-requisites for EYDR configuration (Refer to the readme file)
* Upload and apply the EYDR recipe with `default["establish_replication"]` set to true
* Verify that the slave environment is replicating by logging into the slave environment's DB and executing `select * from pg_stat_wal_receiver;` via postgres
* Update the EYDR configuration by setting `default["establish_replication"]` to false and `default["failover"]` to true, upload and apply
* Verify that the slave environment is **not** replicating by logging into the slave environment's DB and executing `select * from pg_stat_wal_receiver;` via postgres
* Verify that the file `/tmp/postgresql.trigger` has been created on slave environment's DB
* Update the EYDR configuration by setting `default["establish_replication"]` to true and `default["failover"]` to false, upload and apply
* Verify that the slave environment is replicating **again** by logging into the slave environment's DB and executing `select * from pg_stat_wal_receiver;` via postgres
* Verify that the file `/tmp/postgresql.trigger` is no longer on slave environment's DB