### PR TITLE
[fbz-10538]-Add-chef-status-report

### DIFF
--- a/cookbooks/ey-db-ssl/recipes/setup.rb
+++ b/cookbooks/ey-db-ssl/recipes/setup.rb
@@ -9,6 +9,10 @@ owner = node[keyname]["owner"]
 dbroot = node[keyname]["dbroot"]
 ssldir = node[keyname]["ssldir"]
 
+ey_cloud_report "db ssl keys" do
+  message "processing ssl keys started"
+end
+
 managed_template "/engineyard/bin/local_key_copy.sh" do
   owner "root"
   group "root"
@@ -97,4 +101,8 @@ end
 execute "Copy db ssl keys for #{node['dna']['users'].first['username']} from EBS if available" do
   command "/engineyard/bin/local_key_copy.sh #{node['dna']['users'].first['username']}"
   only_if { ::File.exist?(::File.join(ssldir, "root.crt")) and ::File.exist?(::File.join(dbroot, "keygen", node["dna"]["users"].first["username"], "#{keyname}.key")) }
+end
+
+ey_cloud_report "db ssl keys" do
+  message "processing ssl keys finished"
 end

--- a/cookbooks/ey-db_admin_tools/recipes/default.rb
+++ b/cookbooks/ey-db_admin_tools/recipes/default.rb
@@ -1,6 +1,14 @@
+ey_cloud_report "db admin tools" do
+  message "processing db tools started"
+end
+
 case node.engineyard.environment["db_stack_name"]
 when /mysql/
   include_recipe "ey-db_admin_tools::mysql"
 when /postgres/
   include_recipe "ey-db_admin_tools::postgres"
+end
+
+ey_cloud_report "db admin tools" do
+  message "processing db tools finished"
 end

--- a/cookbooks/ey-mysql/recipes/default.rb
+++ b/cookbooks/ey-mysql/recipes/default.rb
@@ -1,6 +1,10 @@
 include_recipe "ey-ebs::default"
 innodb_buff = calc_innodb_buffer_pool()
 
+ey_cloud_report "mysql config" do
+  message "mysql config and dir creation started"
+end
+
 if node.engineyard.instance.arch_type == "arm64"
   raise "Graviton instances are not supported for MySQL currently!"
 end
@@ -109,4 +113,8 @@ directory "/var/run/mysqld" do
   owner "mysql"
   group "mysql"
   mode "755"
+end
+
+ey_cloud_report "mysql config" do
+  message "mysql config and dir creation finished"
 end

--- a/cookbooks/ey-mysql/recipes/install.rb
+++ b/cookbooks/ey-mysql/recipes/install.rb
@@ -1,3 +1,7 @@
+ey_cloud_report "mysql installation" do
+  message "installation of mysql packages and dependencies started"
+end
+
 apt_repository "mysql57" do
   uri "http://repo.percona.com/ps-57/apt"
   distribution "#{`lsb_release -cs`.strip}"
@@ -94,4 +98,8 @@ packages.each do |package|
     ignore_failure true
     only_if { node.engineyard.instance.arch_type == "amd64" }
   end
+end
+
+ey_cloud_report "mysql installation" do
+  message "installation of mysql packages and dependencies finished"
 end

--- a/cookbooks/ey-mysql/recipes/monitoring.rb
+++ b/cookbooks/ey-mysql/recipes/monitoring.rb
@@ -1,5 +1,5 @@
 ey_cloud_report "mysql monitoring" do
-  message "processing mysql monitoring"
+  message "processing mysql monitoring started"
 end
 
 template "/engineyard/bin/check_mysql.sh" do
@@ -11,4 +11,8 @@ template "/engineyard/bin/check_mysql.sh" do
   variables({
     dbpass: node.engineyard.environment["db_admin_password"],
   })
+end
+
+ey_cloud_report "mysql monitoring" do
+  message "processing mysql monitoring finished"
 end

--- a/cookbooks/ey-mysql/recipes/user_my.cnf.rb
+++ b/cookbooks/ey-mysql/recipes/user_my.cnf.rb
@@ -5,6 +5,9 @@
 # Copyright:: 2008, Engine Yard, Inc.
 #
 # All rights reserved - Do Not Redistribute
+ey_cloud_report "db user config" do
+  message "setting up user configuration started"
+end
 
 template "/root/.my.cnf" do
   owner "root"
@@ -34,4 +37,8 @@ template "/home/#{node['owner_name']}/.my.cnf" do
     is_rds: db_host_is_rds?,
   })
   source "user_my.cnf.erb"
+end
+
+ey_cloud_report "db user config" do
+  message "setting up user configuration finished"
 end


### PR DESCRIPTION
Description of your patch
-------------
Adds more cloud reports during chef run

Recommended Release Notes
-------------
Feature added to provide more chef status reports on v7


Estimated risk
-------------
Normal

Components involved
-------------
ey-mysql
ey-db-ssl 
ey-db_admin_tools

Dependencies
-------------
N/A

Description of testing done
-------------
1.) Boot 2 new environments under v7
2.) During chef run, check the reports under instance from the UI

QA Instructions
-------------
1.) Boot 2 new environments under v7
 2.) Each environment with a different DB stack - Postgres, Mysql
3.) During chef run, check the report under instance from the UI