### PR TITLE
[FBZ-10528] Updated paths for elasticsearch Heapdumps and logs

### DIFF
--- a/cookbooks/ey-elasticsearch/recipes/install.rb
+++ b/cookbooks/ey-elasticsearch/recipes/install.rb
@@ -14,6 +14,12 @@ if ES["is_elasticsearch_instance"]
     mode "755"
   end
 
+  directory "/mnt/log/elasticsearch" do
+    owner "elasticsearch"
+    group "elasticsearch"
+    mode "755"
+  end
+
   directory "/data/elasticsearch-#{ES['version']}/data" do
     owner "elasticsearch"
     group "elasticsearch"

--- a/cookbooks/ey-elasticsearch/templates/default/elasticsearch.yml.erb
+++ b/cookbooks/ey-elasticsearch/templates/default/elasticsearch.yml.erb
@@ -1,5 +1,5 @@
 path:
-  logs: /var/log/elasticsearch
+  logs: /mnt/log/elasticsearch
   data: /data/elasticsearch
 
 

--- a/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/templates/default/jvm.options.6.x.erb
+++ b/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/templates/default/jvm.options.6.x.erb
@@ -96,10 +96,10 @@
 
 # specify an alternative path for heap dumps; ensure the directory exists and
 # has sufficient space
--XX:HeapDumpPath=/var/lib/elasticsearch
+-XX:HeapDumpPath=/data/elasticsearch
 
 # specify an alternative path for JVM fatal error logs
--XX:ErrorFile=/var/log/elasticsearch/hs_err_pid%p.log
+-XX:ErrorFile=/mnt/log/elasticsearch/hs_err_pid%p.log
 
 ## JDK 8 GC logging
 
@@ -107,13 +107,13 @@
 8:-XX:+PrintGCDateStamps
 8:-XX:+PrintTenuringDistribution
 8:-XX:+PrintGCApplicationStoppedTime
-8:-Xloggc:/var/log/elasticsearch/gc.log
+8:-Xloggc:/mnt/log/elasticsearch/gc.log
 8:-XX:+UseGCLogFileRotation
 8:-XX:NumberOfGCLogFiles=32
 8:-XX:GCLogFileSize=64m
 
 # JDK 9+ GC logging
-9-:-Xlog:gc*,gc+age=trace,safepoint:file=/var/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=/mnt/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m
 # due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
 # time/date parsing will break in an incompatible way for some date patterns and locals
 9-:-Djava.locale.providers=COMPAT

--- a/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/templates/default/jvm.options.7.x.erb
+++ b/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/templates/default/jvm.options.7.x.erb
@@ -99,23 +99,23 @@
 
 # specify an alternative path for heap dumps; ensure the directory exists and
 # has sufficient space
--XX:HeapDumpPath=/var/lib/elasticsearch
+-XX:HeapDumpPath=/data/elasticsearch
 
 # specify an alternative path for JVM fatal error logs
--XX:ErrorFile=/var/log/elasticsearch/hs_err_pid%p.log
+-XX:ErrorFile=/mnt/log/elasticsearch/hs_err_pid%p.log
 
 ## JDK 8 GC logging
 8:-XX:+PrintGCDetails
 8:-XX:+PrintGCDateStamps
 8:-XX:+PrintTenuringDistribution
 8:-XX:+PrintGCApplicationStoppedTime
-8:-Xloggc:/var/log/elasticsearch/gc.log
+8:-Xloggc:/mnt/log/elasticsearch/gc.log
 8:-XX:+UseGCLogFileRotation
 8:-XX:NumberOfGCLogFiles=32
 8:-XX:GCLogFileSize=64m
 
 # JDK 9+ GC logging
-9-:-Xlog:gc*,gc+age=trace,safepoint:file=/var/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=/mnt/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m
 # due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
 # time/date parsing will break in an incompatible way for some date patterns and locals
 9-:-Djava.locale.providers=COMPAT

--- a/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/templates/default/jvm.options.8.x.erb
+++ b/custom-cookbooks/elasticsearch/cookbooks/custom-elasticsearch/templates/default/jvm.options.8.x.erb
@@ -99,23 +99,23 @@
 
 # specify an alternative path for heap dumps; ensure the directory exists and
 # has sufficient space
--XX:HeapDumpPath=/var/lib/elasticsearch
+-XX:HeapDumpPath=/data/elasticsearch
 
 # specify an alternative path for JVM fatal error logs
--XX:ErrorFile=/var/log/elasticsearch/hs_err_pid%p.log
+-XX:ErrorFile=/mnt/log/elasticsearch/hs_err_pid%p.log
 
 ## JDK 8 GC logging
 8:-XX:+PrintGCDetails
 8:-XX:+PrintGCDateStamps
 8:-XX:+PrintTenuringDistribution
 8:-XX:+PrintGCApplicationStoppedTime
-8:-Xloggc:/var/log/elasticsearch/gc.log
+8:-Xloggc:/mnt/log/elasticsearch/gc.log
 8:-XX:+UseGCLogFileRotation
 8:-XX:NumberOfGCLogFiles=32
 8:-XX:GCLogFileSize=64m
 
 # JDK 9+ GC logging
-9-:-Xlog:gc*,gc+age=trace,safepoint:file=/var/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=/mnt/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m
 # due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
 # time/date parsing will break in an incompatible way for some date patterns and locals
 9-:-Djava.locale.providers=COMPAT


### PR DESCRIPTION
Description of your patch
-------------
The patch mounts heapdumps default directory to `/data/elasticsearch` and elasticsearch logs to `/mnt/log/elasticsearch` . This enables us to expand the volumes in case free space runs out due to elasticsearch.

Recommended Release Notes
-------------

The patch mounts heapdumps default directory to `/data/elasticsearch` and elasticsearch logs to `/mnt/log/elasticsearch`

Estimated risk
-------------

Normal

Components involved
-------------
`ey-elasticsearch`

Dependencies
-------------
None

Description of testing done
-------------
1. Boot an environment with an elasticsearch util instance
2. Overlay the `ey-elasticsearch` cookbook.
3. Re-apply recipes
4. Check where elasticsearch logs appear (should be `/mnt/log/elasticsearch`)
5. Check where elasticsearch heapdumps appear after a while (should be `/data/elasticsearch`)

QA Instructions
-------------
1. Boot an environment with an elasticsearch util instance
2. Overlay the `ey-elasticsearch` cookbook.
3. Re-apply recipes
4. Check where elasticsearch logs appear (should be `/mnt/log/elasticsearch`)
5. Check where elasticsearch heapdumps appear after a while (should be `/data/elasticsearch`)
