### PR TITLE
[FBZ-10545] Fix for mysqld installed and running on app and util 

### DIFF
--- a/cookbooks/ey-mysql/recipes/install.rb
+++ b/cookbooks/ey-mysql/recipes/install.rb
@@ -50,10 +50,10 @@ end
 
 package "libmysqlclient-dev"
 # installs mysql client to all instnaces. 
-if node.engineyard.instance.arch_type == "amd64"
-    package "percona-server-client"
+if node.engineyard.instance.arch_type == "arm64"
+    package "mysql-client"
 else
-  package "mysql-client"
+  package "percona-server-client"
 end
 
 case node["mysql"]["short_version"]

--- a/cookbooks/ey-mysql/recipes/install.rb
+++ b/cookbooks/ey-mysql/recipes/install.rb
@@ -49,6 +49,7 @@ end
 end
 
 package "libmysqlclient-dev"
+package "percona-server-client"
 
 case node["mysql"]["short_version"]
 when "5.7"

--- a/cookbooks/ey-mysql/recipes/install.rb
+++ b/cookbooks/ey-mysql/recipes/install.rb
@@ -50,7 +50,11 @@ end
 
 package "libmysqlclient-dev"
 # installs mysql client to all instnaces. 
-package "percona-server-client"
+if node.engineyard.instance.arch_type == "amd64"
+    package "percona-server-client"
+else
+  package "mysql-client"
+end
 
 case node["mysql"]["short_version"]
 when "5.7"

--- a/cookbooks/ey-mysql/recipes/install.rb
+++ b/cookbooks/ey-mysql/recipes/install.rb
@@ -91,6 +91,7 @@ execute "set-deb-confs" do
 end
 
 # Loop the packages because chef doesn't understand, you install the dependency before even in the array...
+if node["dna"]["instance_role"][/^(db|solo)/]
 packages.each do |package|
   apt_package package do
     version "#{package_version}"
@@ -99,6 +100,7 @@ packages.each do |package|
     ignore_failure true
     only_if { node.engineyard.instance.arch_type == "amd64" }
   end
+end
 end
 
 ey_cloud_report "mysql installation" do

--- a/cookbooks/ey-mysql/recipes/install.rb
+++ b/cookbooks/ey-mysql/recipes/install.rb
@@ -49,6 +49,7 @@ end
 end
 
 package "libmysqlclient-dev"
+# installs mysql client to all instnaces. 
 package "percona-server-client"
 
 case node["mysql"]["short_version"]


### PR DESCRIPTION
### Description of your patch
Fix for mysqld installed and running on app and util instances 

### Recommended Release Notes
Fix for mysqld installed and running on app and util instances 

### Estimated risk
High

### Components involved
All clients who use MySQL as DB stack.

### Dependencies
ey-mysql

### Description of testing done
Case1:

- Create v7 environment with this fix ovelayed , with DB provider as MySQL 5.7. 
- Boot environmnet with application Master, DB Master and Utility Instance.  
- Check on application and utility instance if mysqld is running using `ps -aux |grep mysql`, is should not be running on app and util instances.  Also, try to connect to DB using `mysql -u root` it should connect you to the DB master. 

Case2:

- Create v7 environment with this fix ovelayed , with DB provider as 8.0
- Boot environmnet with application Master, DB Master and Utility Instance.  
- Check on application and utility instance if mysqld is running using `ps -aux |grep mysql`, is should not be running on app and util instances.  Also, try to connect to DB using `mysql -u root` it should connect you to the DB master. 