### PR TITLE
Adding GEM_PATH to startup script

### DIFF
--- a/cookbooks/ey-passenger5/recipes/install.rb
+++ b/cookbooks/ey-passenger5/recipes/install.rb
@@ -41,6 +41,8 @@ framework_env = node["dna"]["environment"]["framework_env"]
 base_port = node["passenger5"]["port"].to_i
 stepping = 200
 app_base_port = base_port
+# For GEM_PATH and others, the major version is needed. I.e: '3.0.0' instead of '3.0.2'
+ruby_major_version = node["ruby"]["version"].sub(/(\d\.\d).\d*/, '\1.0')
 
 node.engineyard.apps.each_with_index do |app, index|
   app_path      = "/data/#{app.name}"
@@ -59,7 +61,8 @@ node.engineyard.apps.each_with_index do |app, index|
       version: version,
       port: app_base_port,
       worker_count: recipe.get_pool_size,
-      rails_env: framework_env
+      rails_env: framework_env, 
+      ruby_version: ruby_major_version
     )
   end
 

--- a/cookbooks/ey-passenger5/templates/default/app_control.erb
+++ b/cookbooks/ey-passenger5/templates/default/app_control.erb
@@ -17,6 +17,9 @@ export HOME="/home/<%= @user %>"
 #source "/data/<%= @app_name %>/shared/config/env.custom"
 #source "/data/<%= @app_name %>/shared/config/env.cloud"
 
+# Setting the GEM_PATH so that Passenger uses the app's gems
+export GEM_PATH="/data/<%= @app_name %>/shared/bundled_gems/ruby/<%= @ruby_version %>/"
+
 cd /data/<%= @app_name %>/
 
 case "$1" in


### PR DESCRIPTION
Description of your patch
-------------
Add GEM_PATH to Passenger's startup script. Handles #224 

Recommended Release Notes
-------------
Add GEM_PATH to Passenger's startup script.

Estimated risk
-------------
Medium - This affects the startup script of all apps running Passenger.

Components involved
-------------
Customers using Passenger as an app server.

Dependencies
-------------
N/A

Description of testing done
-------------
- Create an app with a source code that includes gem `base64` on a version different than `0.1.0`.
- Create a v7 environment
- Select Passenger as the app server.
- Deploy the app.
- The app will fail to start, printing a message like `You have already activated base64 0.1.0, but your Gemfile requires base64 0.1.1`. This can be seen in logfile `/data/<app_name>/current/log/passenger.8000.log`
- Apply this PR as an overlay on the environment.
- Log into the instance and run `su - deploy -c '/engineyard/bin/app_<app_name>` restart.
- Confirm that passenger is up & running by checking the log.

QA Instructions
-------------
- Create an app with a source code that includes gem `base64` on a version different than `0.1.0`.
- Create a v7 environment
- Select Passenger as the app server.
- Deploy the app.
- The app will fail to start, printing a message like `You have already activated base64 0.1.0, but your Gemfile requires base64 0.1.1`. This can be seen in logfile `/data/<app_name>/current/log/passenger.8000.log`
- Apply this PR as an overlay on the environment.
- Log into the instance and run `su - deploy -c '/engineyard/bin/app_<app_name>` restart.
- Confirm that passenger is up & running by checking the log.
