### PR TITLE
GHI-3294 - Added Ruby 3.2

### DIFF
--- a/cookbooks/ey-lib/libraries/ey-environment.rb
+++ b/cookbooks/ey-lib/libraries/ey-environment.rb
@@ -123,6 +123,7 @@ class Chef
           ruby_270: "2.7.1",
           ruby_300: "3.0.2",
           ruby_310: "3.1.1",
+          ruby_320: "3.2.0",
         }
         if versions.key?(ruby_archtype.to_sym)
           version = versions[ruby_archtype.to_sym]


### PR DESCRIPTION
Description of your patch
-------------
The fix for https://github.com/trilogy-group/eng-maintenance/issues/3294.
Updated the helper fucntion `Chef::EY::Environment#default_ruby_version` for `ey-ruby` recipe - added Ruby 3.2.0. This enables it during the env configuration.

Recommended Release Notes
-------------
Added the Ruby 3.2 - made it available when configuring the environment.

Estimated risk
-------------
Low - it affects only the new env that will be created.

Components involved
-------------
`ey-ruby` recipe, its helper function.

Dependencies
-------------
N/A

Description of testing done
-------------
- Created the new qa stack release that includes the updated recipe - `stable-v7-qa-1.0.49`
- Created a new test app env in Sunset using the updated stack release. Configured it with Ruby 3.2
- Booted the env (solo instance)
- The env infrastructure has been created successfully - the instance was marked as green in the AWSM UI
- SSHed to the instance and checked the Ruby version - it gave `ruby 3.2.0`