### PR TITLE
GHI-229 - Sidekiq service memory usage limits

### DIFF
--- a/cookbooks/ey-sidekiq/attributes/default.rb
+++ b/cookbooks/ey-sidekiq/attributes/default.rb
@@ -36,6 +36,7 @@ default["sidekiq"].tap do |sidekiq|
 
   # Memory limit
   sidekiq["worker_memory"] = fetch_env_var(node, "EY_SIDEKIQ_WORKER_MEMORY_MB", 400).to_i # MB
+  sidekiq["worker_threshold_memory"] = fetch_env_var(node, "EY_SIDEKIQ_WORKER_THRESHOLD_MEMORY_MB", sidekiq["worker_memory"]*8/10).to_i # MB
 
   # Verbose
   sidekiq["verbose"] = fetch_env_var(node, "EY_SIDEKIQ_VERBOSE", false).to_s == "true"

--- a/cookbooks/ey-sidekiq/recipes/setup.rb
+++ b/cookbooks/ey-sidekiq/recipes/setup.rb
@@ -23,7 +23,8 @@ if node["sidekiq"]["is_sidekiq_instance"]
           count: count,
           user: node.engineyard.environment.ssh_username,
           rails_env: node["dna"]["environment"]["framework_env"],
-          memory_limit: node["sidekiq"]["worker_memory"]
+          memory_limit: node["sidekiq"]["worker_memory"],
+          memory_limit_threshold: node["sidekiq"]["worker_threshold_memory"]
         )
         notifies :run, "execute[restart-sidekiq-for-#{app_name}-#{count}]"
       end

--- a/cookbooks/ey-sidekiq/templates/default/sidekiq.service.erb
+++ b/cookbooks/ey-sidekiq/templates/default/sidekiq.service.erb
@@ -16,4 +16,5 @@ StandardOutput=append:/data/<%= @app_name %>/current/log/sidekiq_<%= @count %>.l
 StandardError=append:/data/<%= @app_name %>/current/log/sidekiq_<%= @count %>.stderr.log
 MemoryMax=<%= @memory_limit %>M
 MemorySwapMax=<%= @memory_limit %>M
+MemoryHigh=<%= @memory_limit_threshold %>M
 EnvironmentFile=/data/<%= @app_name %>/shared/config/env.sidekiq.cloud

--- a/cookbooks/ey-sidekiq/templates/default/sidekiq.service.erb
+++ b/cookbooks/ey-sidekiq/templates/default/sidekiq.service.erb
@@ -15,4 +15,5 @@ Restart=on-failure
 StandardOutput=append:/data/<%= @app_name %>/current/log/sidekiq_<%= @count %>.log
 StandardError=append:/data/<%= @app_name %>/current/log/sidekiq_<%= @count %>.stderr.log
 MemoryMax=<%= @memory_limit %>M
+MemorySwapMax=<%= @memory_limit %>M
 EnvironmentFile=/data/<%= @app_name %>/shared/config/env.sidekiq.cloud


### PR DESCRIPTION
### Description of your patch
Declared MemorySwapMax and MemoryHigh limit for the sidekiq service. Added environment variable "EY_SIDEKIQ_WORKER_THRESHOLD_MEMORY_MB" for MemoryHigh limit of the sidekiq service. It is by default 80% of the MemoryMax. Related issue #229 

### Recommended Release Notes
Environment variable for threshold memory limit of sidekiq service.

### Estimated Risk
Low ( After these changes are applied all sidekiq workers will have these limits applied)

### Components involved
All clients who use sidekiq in their application

### Dependencies
ey-sidekiq

### Description of testing done
Create a v7 rails environment with sidekiq
Add environment variables to enable sidekiq in the environment
Run command "systemctl status [sidekiq worker name]" on the instance that sidekiq is running.
Look at the memory row in the output, Max, SwapMax and High limits should be declared. 