### PR TITLE
Update ey-core default recipe: postgres archive sources and yarn signature key

### DIFF
--- a/cookbooks/ey-core/recipes/default.rb
+++ b/cookbooks/ey-core/recipes/default.rb
@@ -12,9 +12,9 @@ end
 
 execute "update-apt-sources" do
   command <<-EOH
-    cp /etc/apt/sources.list /etc/apt/sources.list.bak &&
-    sed -i 's|http://.*.ec2.archive.ubuntu.com/ubuntu/|http://archive.ubuntu.com/ubuntu/|g' /etc/apt/sources.list &&
-    apt-get update
+    sed -i.bak 's|http://.*.ec2.archive.ubuntu.com/ubuntu/|http://archive.ubuntu.com/ubuntu/|g' /etc/apt/sources.list &&
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - &&
+    sed -i.bak 's|http://apt.postgresql.org/pub/repos/apt|http://apt-archive.postgresql.org/pub/repos/apt|g' /etc/apt/sources.list.d/posgresql.list
   EOH
   action :run
 end

--- a/cookbooks/ey-db-libs/recipes/default.rb
+++ b/cookbooks/ey-db-libs/recipes/default.rb
@@ -1,7 +1,7 @@
 postgres_version = node["postgresql"]["short_version"].nil? || node["postgresql"]["short_version"] == {} || node["postgresql"]["short_version"].to_i == 11 ? "all" : node["postgresql"]["short_version"]
 
 apt_repository "posgresql" do
-  uri "http://apt.postgresql.org/pub/repos/apt"
+  uri "http://apt-archive.postgresql.org/pub/repos/apt"
   distribution "#{`lsb_release -cs`.strip}-pgdg"
   components ["main"]
   key "https://www.postgresql.org/media/keys/ACCC4CF8.asc"


### PR DESCRIPTION
This PR addresses Issue #250

- Update postgres sources to use apt-archive.postgresql.org instead of apt.postgresql.org
- Add yarn signing key for secure package installation
- Use sed -i.bak for backup files instead of cp
- Remove redundant apt-get update (handled by apt_update Chef resource)

This change improves package source reliability and security for Engine Yard environments.