### PR TITLE
Fix unconditional PGDG repo addition and EOL repository URL

### DIFF
--- a/cookbooks/ey-db-libs/recipes/default.rb
+++ b/cookbooks/ey-db-libs/recipes/default.rb
@@ -1,12 +1,15 @@
 postgres_version = node["postgresql"]["short_version"].nil? || node["postgresql"]["short_version"] == {} || node["postgresql"]["short_version"].to_i == 11 ? "all" : node["postgresql"]["short_version"]
 
-apt_repository "posgresql" do
-  uri "http://apt.postgresql.org/pub/repos/apt"
-  distribution "#{`lsb_release -cs`.strip}-pgdg"
-  components ["main"]
-  key "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
-end
+# Only add PostgreSQL repository and install PostgreSQL dev packages when actually using PostgreSQL stack
+if node["dna"]["engineyard"]["environment"]["db_stack_name"] =~ /^postgres|^aurora-postgresql/
+  apt_repository "posgresql" do
+    uri "https://apt-archive.postgresql.org/pub/repos/apt"
+    distribution "#{`lsb_release -cs`.strip}-pgdg-archive"
+    components ["main"]
+    key "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
+  end
 
-package "postgresql-server-dev-#{postgres_version}"
+  package "postgresql-server-dev-#{postgres_version}"
+end
 package "libmysqlclient-dev"
 package "libsqlite3-dev"

--- a/cookbooks/ey-postgresql/recipes/server_install.rb
+++ b/cookbooks/ey-postgresql/recipes/server_install.rb
@@ -1,9 +1,12 @@
-apt_repository "posgresql" do
-  uri "https://apt-archive.postgresql.org/pub/repos/apt"
-  distribution "#{`lsb_release -cs`.strip}-pgdg-archive"
-  components ["main"]
-  key "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
-end.run_action(:add)
+# Only add PostgreSQL repository when actually using PostgreSQL stack
+if node["dna"]["engineyard"]["environment"]["db_stack_name"] =~ /^postgres|^aurora-postgresql/
+  apt_repository "posgresql" do
+    uri "https://apt-archive.postgresql.org/pub/repos/apt"
+    distribution "#{`lsb_release -cs`.strip}-pgdg-archive"
+    components ["main"]
+    key "https://www.postgresql.org/media/keys/ACCC4CF8.asc"
+  end.run_action(:add)
+end
 
 apt_update
 


### PR DESCRIPTION
- Add conditional logic to only add PostgreSQL repository when using PostgreSQL/Aurora-PostgreSQL stacks
- Update repository URL to use https://apt-archive.postgresql.org for Ubuntu 20.04 compatibility
- Fix ey-postgresql::server_install and ey-db-libs::default recipes
- Prevents apt-get update failures on MySQL environments
- Only install postgresql-server-dev packages when PostgreSQL is the database stack