### PR TITLE
feat: add Ruby 3.3/3.4 default patch version mappings

### DIFF
--- a/cookbooks/ey-lib/libraries/ey-environment.rb
+++ b/cookbooks/ey-lib/libraries/ey-environment.rb
@@ -124,6 +124,8 @@ class Chef
           ruby_300: "3.0.2",
           ruby_310: "3.1.1",
           ruby_320: "3.2.0",
+          ruby_330: "3.3.10",
+          ruby_340: "3.4.9",
         }
         if versions.key?(ruby_archtype.to_sym)
           version = versions[ruby_archtype.to_sym]


### PR DESCRIPTION
## Summary
- Add `ruby_330: "3.3.10"` and `ruby_340: "3.4.9"` to the `default_ruby_version` hash in `ey-environment.rb`
- Patch versions match DNApi 2.0.11 (`PATCH_LEVEL` of `p10` and `p9` respectively)
- `ruby_320` confirmed present (no action needed)
- Cookstyle linting passes (only pre-existing offense on line 4, unrelated)

Closes trilogy-group/ey-all#40

## Test plan
- [x] Verified `ruby_320` already present in hash
- [x] Cookstyle linting passes with no new offenses
- [ ] Deploy to staging environment and verify Chef run with Ruby 3.3/3.4 archetypes

🤖 Generated with [Claude Code](https://claude.com/claude-code)