### PR TITLE
[21914] Fix pg_extension NameError for ext_name under Chef 17

### DIFF
--- a/.github/workflows/ey-postgresql-tests.yml
+++ b/.github/workflows/ey-postgresql-tests.yml
@@ -1,0 +1,81 @@
+name: ey-postgresql tests
+
+# Runs the ey-postgresql regression suite as a PR check. Covers GHI-21914:
+# the pg_extension custom resource must read its properties via new_resource.*
+# under Chef 17, quote VERSION/FROM in CREATE EXTENSION, and the
+# server_configure "process extensions.json" block must resolve the resource
+# via declare_resource (not the stale Chef::Resource::PostgresqlPgExtension).
+
+on:
+  pull_request:
+    paths:
+      - "cookbooks/ey-postgresql/**"
+      - ".github/workflows/ey-postgresql-tests.yml"
+  push:
+    branches: [next-release]
+    paths:
+      - "cookbooks/ey-postgresql/**"
+      - ".github/workflows/ey-postgresql-tests.yml"
+
+jobs:
+  pg-extension:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      # The pg_extension resource runs `psql -U postgres` with no host/port, so
+      # it (and the test harness) picks up the connection from these env vars.
+      PGHOST: localhost
+      PGPORT: "5432"
+      PGUSER: postgres
+      PGPASSWORD: postgres
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install PostgreSQL client (psql)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+
+      - name: Install Chef (17.x)
+        working-directory: cookbooks/ey-postgresql/spec
+        run: |
+          gem install bundler
+          bundle install --jobs 4
+          # expose chef-solo on PATH for the guard script and the harness
+          echo "$(bundle exec ruby -e 'print Gem.bindir')" >> "$GITHUB_PATH"
+
+      - name: Wait for PostgreSQL
+        run: |
+          for i in $(seq 1 30); do
+            pg_isready -h localhost -p 5432 -U postgres && break
+            sleep 2
+          done
+          psql -c "SELECT version();"
+
+      - name: Integration tests (live PostgreSQL)
+        working-directory: cookbooks/ey-postgresql/spec
+        run: bundle exec ruby pg_extension_integration_test.rb
+
+      - name: No-DB regression guard
+        # chef-solo is already on PATH (Gem.bindir added in the install step).
+        run: ./cookbooks/ey-postgresql/spec/pg_extension_regression.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+cookbooks/ey-postgresql/spec/Gemfile.lock

--- a/cookbooks/ey-postgresql/recipes/server_configure.rb
+++ b/cookbooks/ey-postgresql/recipes/server_configure.rb
@@ -319,12 +319,12 @@ end
 
 ruby_block "process extensions.json" do
   block do
-    # run_context = Chef::RunContext.new(node, {})
     exts = JSON.parse(::File.read(node["pg_extensions_file"]))
-    exts.each do |db_name, exts|
-      run_context.resource_collection << r = Chef::Resource::PostgresqlPgExtension.new("install #{exts.join(',')} in database #{db_name}", run_context)
-      r.db_name = db_name
-      r.ext_name = exts
+    exts.each do |db, ext_list|
+      declare_resource(:ey_postgresql_pg_extension, "install #{ext_list.join(',')} in database #{db}") do
+        db_name db
+        ext_name ext_list
+      end
     end
   end
   only_if { ::File.exist?(node["pg_extensions_file"]) }

--- a/cookbooks/ey-postgresql/resources/createdb.rb
+++ b/cookbooks/ey-postgresql/resources/createdb.rb
@@ -8,9 +8,9 @@ default_action :createdb_action
 
 action :createdb_action do
   if ["solo", "db_master"].include?(node["dna"]["instance_role"])
-    execute "create database for #{db_name}" do
-      command %(psql -U postgres postgres -c \"CREATE DATABASE #{db_name} OWNER #{owner}\")
-      not_if %(psql -U postgres -t -c "select datname from pg_database where datname = '#{db_name}';" | grep #{db_name})
+    execute "create database for #{new_resource.name}" do
+      command %(psql -U postgres postgres -c \"CREATE DATABASE #{new_resource.name} OWNER #{new_resource.owner}\")
+      not_if %(psql -U postgres -t -c "select datname from pg_database where datname = '#{new_resource.name}';" | grep #{new_resource.name})
     end
   end
 end

--- a/cookbooks/ey-postgresql/resources/pg_extension.rb
+++ b/cookbooks/ey-postgresql/resources/pg_extension.rb
@@ -10,8 +10,8 @@ property :old_version, String
 property :use_load, [true, false], default: false # use LOAD instead of CREATE EXTENSION
 
 action :install do
-  ext_names = ext_name.is_a?(String) ? [ext_name] : ext_name
-  db_names = db_name.is_a?(String) ? [db_name] : db_name
+  ext_names = new_resource.ext_name.is_a?(String) ? [new_resource.ext_name] : new_resource.ext_name
+  db_names = new_resource.db_name.is_a?(String) ? [new_resource.db_name] : new_resource.db_name
   postgres_version = node["postgresql"]["short_version"]
 
   if node["dna"]["instance_role"][/^(db|solo)/]
@@ -31,7 +31,7 @@ action :install do
         # the main extension/library install bit
         if node["dna"]["instance_role"][/db_master|solo/]
           Chef::Log.info "Installing PostgreSQL extension #{ext_name} to database #{db_name}."
-          do_load = ext_details[:use_load].nil? ? (use_load || false) : (ext_details[:use_load] || use_load)
+          do_load = ext_details[:use_load].nil? ? (new_resource.use_load || false) : (ext_details[:use_load] || new_resource.use_load)
           if do_load
             cmd = "LOAD"
             quoted_ext_name = "'#{ext_name}'"
@@ -40,7 +40,7 @@ action :install do
             quoted_ext_name = %(\\"#{ext_name}\\")
           end
           execute "Postgresql loading #{do_load ? 'library' : 'extension'} #{ext_name}" do
-            command %(psql -U postgres -d #{db_name} -c "#{cmd} #{quoted_ext_name} #{"SCHEMA #{schema_name}" unless schema_name.nil?} #{"VERSION #{version}" unless version.nil?} #{"FROM #{old_version}" unless old_version.nil?};")
+            command %(psql -U postgres -d #{db_name} -c "#{cmd} #{quoted_ext_name} #{"SCHEMA #{new_resource.schema_name}" unless new_resource.schema_name.nil?} #{"VERSION #{new_resource.version}" unless new_resource.version.nil?} #{"FROM #{new_resource.old_version}" unless new_resource.old_version.nil?};")
           end
 
           # and a couple follow up commands for Postgis

--- a/cookbooks/ey-postgresql/resources/pg_extension.rb
+++ b/cookbooks/ey-postgresql/resources/pg_extension.rb
@@ -40,7 +40,7 @@ action :install do
             quoted_ext_name = %(\\"#{ext_name}\\")
           end
           execute "Postgresql loading #{do_load ? 'library' : 'extension'} #{ext_name}" do
-            command %(psql -U postgres -d #{db_name} -c "#{cmd} #{quoted_ext_name} #{"SCHEMA #{new_resource.schema_name}" unless new_resource.schema_name.nil?} #{"VERSION #{new_resource.version}" unless new_resource.version.nil?} #{"FROM #{new_resource.old_version}" unless new_resource.old_version.nil?};")
+            command %(psql -U postgres -d #{db_name} -c "#{cmd} #{quoted_ext_name} #{"SCHEMA #{new_resource.schema_name}" unless new_resource.schema_name.nil?} #{"VERSION '#{new_resource.version}'" unless new_resource.version.nil?} #{"FROM '#{new_resource.old_version}'" unless new_resource.old_version.nil?};")
           end
 
           # and a couple follow up commands for Postgis

--- a/cookbooks/ey-postgresql/spec/Gemfile
+++ b/cookbooks/ey-postgresql/spec/Gemfile
@@ -5,3 +5,7 @@ source "https://rubygems.org"
 
 gem "chef", "17.9.46"
 gem "chef-bin", "17.9.46"
+
+# Test framework for pg_extension_integration_test.rb. Pinned so `bundle exec`
+# finds it regardless of what ships as a default gem in the CI Ruby.
+gem "minitest", "~> 5.0"

--- a/cookbooks/ey-postgresql/spec/Gemfile
+++ b/cookbooks/ey-postgresql/spec/Gemfile
@@ -1,0 +1,7 @@
+# Test-only dependencies for the ey-postgresql regression suite.
+# Pins Chef to the version deployed on the Stack v7 (Chef 17) so the tests
+# exercise the same custom-resource property/DSL behavior as production.
+source "https://rubygems.org"
+
+gem "chef", "17.9.46"
+gem "chef-bin", "17.9.46"

--- a/cookbooks/ey-postgresql/spec/README.md
+++ b/cookbooks/ey-postgresql/spec/README.md
@@ -1,0 +1,21 @@
+# ey-postgresql regression tests
+
+Self-contained checks that need only `chef-solo` on the PATH
+(`gem install chef chef-bin`) — no ChefSpec / Test Kitchen / running database.
+
+## pg_extension_regression.sh
+
+Guards against GHI-21914: the `pg_extension` custom resource must read its
+properties via `new_resource.*` inside `action :install`, otherwise Chef 17
+raises `NameError: undefined local variable or method 'ext_name'` and normal
+Apply fails for any custom cookbook that uses `pg_extension` (e.g. to install
+PostGIS).
+
+The script converges the resource with the customer's exact invocation (single
+string values) and the array form. A PostgreSQL server is not required — the
+run legitimately stops at the `psql` step with a connection error, which the
+guard ignores; only a `NameError` (or failing to reach the resource) fails it.
+
+```bash
+cookbooks/ey-postgresql/spec/pg_extension_regression.sh   # exit 0 = pass
+```

--- a/cookbooks/ey-postgresql/spec/README.md
+++ b/cookbooks/ey-postgresql/spec/README.md
@@ -1,21 +1,21 @@
 # ey-postgresql regression tests
 
-Automated coverage for the `pg_extension` fixes made for GHI-21914 (Engine Yard
-v7 `pg_extension` failing under Chef 17). Two layers:
+Automated coverage for the fixes made for GHI-21914 (Engine Yard v7
+`ey-postgresql` custom resources failing under Chef 17). Two layers:
 
 | File | Needs a DB? | Covers |
 |------|-------------|--------|
-| `pg_extension_integration_test.rb` | **Yes** (live PostgreSQL) | All three fixes, asserted against real database state |
-| `pg_extension_regression.sh` | No (chef-solo only) | Fast `NameError` gate for String + Array property forms |
+| `pg_extension_integration_test.rb` | **Yes** (live PostgreSQL) | All four fixes, asserted against real database state |
+| `pg_extension_regression.sh` | No (chef-solo only) | Fast `NameError` gate for `pg_extension` (String + Array) and `createdb` |
 
 Both run in CI on every PR touching `cookbooks/ey-postgresql/**` — see
 `.github/workflows/ey-postgresql-tests.yml` (PostgreSQL service container,
 Chef 17 via `spec/Gemfile`).
 
-## The three fixes under test
+## The four fixes under test
 
-1. **Property access** — `action :install` must read properties via
-   `new_resource.*`. Bare `ext_name`/`db_name` raised
+1. **Property access (`pg_extension`)** — `action :install` must read properties
+   via `new_resource.*`. Bare `ext_name`/`db_name` raised
    `NameError: undefined local variable or method 'ext_name'` under Chef 17.
    Covered for **both** single-string and Array-typed values.
 2. **SQL quoting** — `CREATE EXTENSION ... VERSION '<v>'` / `FROM '<v>'` must be
@@ -24,6 +24,11 @@ Chef 17 via `spec/Gemfile`).
    must resolve the resource via `declare_resource(:ey_postgresql_pg_extension, …)`;
    the old `Chef::Resource::PostgresqlPgExtension` constant (a pre-rename name)
    raised `uninitialized constant` on every Apply that had an `extensions.json`.
+4. **Property access (`createdb`)** — same bug class in the sibling `createdb`
+   resource: `action :createdb_action` read `db_name`/`owner` as bare identifiers
+   (and `db_name` was not even a declared property — the DB-name property is
+   `name`), raising `NameError` for any customer cookbook that calls
+   `createdb 'x' do … end`. Fixed to `new_resource.name` / `new_resource.owner`.
 
 ## Running locally
 
@@ -44,5 +49,5 @@ PGHOST=localhost PGPORT=5432 PGUSER=postgres PGPASSWORD=postgres \
 bundle exec ./pg_extension_regression.sh   # exit 0 = pass, 1 = regression
 ```
 
-Each test is self-checking: reverting any one of the three fixes turns the
+Each test is self-checking: reverting any one of the four fixes turns the
 corresponding assertion red (verified during development).

--- a/cookbooks/ey-postgresql/spec/README.md
+++ b/cookbooks/ey-postgresql/spec/README.md
@@ -1,21 +1,48 @@
 # ey-postgresql regression tests
 
-Self-contained checks that need only `chef-solo` on the PATH
-(`gem install chef chef-bin`) — no ChefSpec / Test Kitchen / running database.
+Automated coverage for the `pg_extension` fixes made for GHI-21914 (Engine Yard
+v7 `pg_extension` failing under Chef 17). Two layers:
 
-## pg_extension_regression.sh
+| File | Needs a DB? | Covers |
+|------|-------------|--------|
+| `pg_extension_integration_test.rb` | **Yes** (live PostgreSQL) | All three fixes, asserted against real database state |
+| `pg_extension_regression.sh` | No (chef-solo only) | Fast `NameError` gate for String + Array property forms |
 
-Guards against GHI-21914: the `pg_extension` custom resource must read its
-properties via `new_resource.*` inside `action :install`, otherwise Chef 17
-raises `NameError: undefined local variable or method 'ext_name'` and normal
-Apply fails for any custom cookbook that uses `pg_extension` (e.g. to install
-PostGIS).
+Both run in CI on every PR touching `cookbooks/ey-postgresql/**` — see
+`.github/workflows/ey-postgresql-tests.yml` (PostgreSQL service container,
+Chef 17 via `spec/Gemfile`).
 
-The script converges the resource with the customer's exact invocation (single
-string values) and the array form. A PostgreSQL server is not required — the
-run legitimately stops at the `psql` step with a connection error, which the
-guard ignores; only a `NameError` (or failing to reach the resource) fails it.
+## The three fixes under test
+
+1. **Property access** — `action :install` must read properties via
+   `new_resource.*`. Bare `ext_name`/`db_name` raised
+   `NameError: undefined local variable or method 'ext_name'` under Chef 17.
+   Covered for **both** single-string and Array-typed values.
+2. **SQL quoting** — `CREATE EXTENSION ... VERSION '<v>'` / `FROM '<v>'` must be
+   quoted; unquoted `VERSION 1.4` was a PostgreSQL syntax error.
+3. **Dynamic path** — `server_configure.rb`'s "process extensions.json" block
+   must resolve the resource via `declare_resource(:ey_postgresql_pg_extension, …)`;
+   the old `Chef::Resource::PostgresqlPgExtension` constant (a pre-rename name)
+   raised `uninitialized constant` on every Apply that had an `extensions.json`.
+
+## Running locally
+
+Prerequisites: `chef-solo` on PATH (`cd spec && bundle install`), and — for the
+integration test — a reachable PostgreSQL superuser `postgres`. The bundled
+extensions used (`hstore`, `pg_trgm`) ship with core PostgreSQL, so no PostGIS
+packages are required.
 
 ```bash
-cookbooks/ey-postgresql/spec/pg_extension_regression.sh   # exit 0 = pass
+cd cookbooks/ey-postgresql/spec
+bundle install
+
+# Integration test (real DB). psql -U postgres must connect via PG* env vars:
+PGHOST=localhost PGPORT=5432 PGUSER=postgres PGPASSWORD=postgres \
+  bundle exec ruby pg_extension_integration_test.rb
+
+# Fast no-DB gate:
+bundle exec ./pg_extension_regression.sh   # exit 0 = pass, 1 = regression
 ```
+
+Each test is self-checking: reverting any one of the three fixes turns the
+corresponding assertion red (verified during development).

--- a/cookbooks/ey-postgresql/spec/pg_extension_integration_test.rb
+++ b/cookbooks/ey-postgresql/spec/pg_extension_integration_test.rb
@@ -1,0 +1,203 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Integration tests for the ey-postgresql `pg_extension` resource (GHI-21914).
+#
+# These converge the REAL resource file with `chef-solo` against a REAL running
+# PostgreSQL and assert the resulting database state. They cover all three
+# Chef-17-era fixes made on PR #258:
+#
+#   1. Property access via `new_resource.*` inside `action :install`
+#      (the original `NameError: undefined local variable or method 'ext_name'`).
+#      Covered for BOTH single-string and Array-typed `ext_name`/`db_name`.
+#   2. `VERSION '...'` / `FROM '...'` quoting in the CREATE EXTENSION command
+#      (unquoted `VERSION 1.4` raised a PostgreSQL syntax error).
+#   3. The `server_configure.rb` "process extensions.json" block using
+#      `declare_resource(:ey_postgresql_pg_extension, ...)` instead of the stale
+#      `Chef::Resource::PostgresqlPgExtension` constant (which raised
+#      `uninitialized constant` under Chef 17 on every Apply with an
+#      extensions.json).
+#
+# Requirements (see spec/README.md):
+#   - `chef-solo` on PATH  (gem install chef chef-bin)
+#   - a reachable PostgreSQL superuser `postgres`
+#   - env: PGHOST/PGPORT (default socket) so `psql -U postgres` connects.
+#     The bundled extensions used (hstore, pg_trgm) ship with core PostgreSQL,
+#     so no PostGIS packages are required.
+#
+# Run:  ruby cookbooks/ey-postgresql/spec/pg_extension_integration_test.rb
+
+require "minitest/autorun"
+require "json"
+require "tmpdir"
+require "fileutils"
+
+module PgExtHarness
+  SPEC_DIR = __dir__
+  EYPG_DIR = File.expand_path("..", SPEC_DIR)                       # cookbooks/ey-postgresql
+  RESOURCE = File.join(EYPG_DIR, "resources", "pg_extension.rb")
+  SERVER_CONFIGURE = File.join(EYPG_DIR, "recipes", "server_configure.rb")
+
+  module_function
+
+  def psql(sql, db: "postgres")
+    out = `psql -U postgres -d #{db} -Atqc #{sql.inspect} 2>&1`
+    raise "psql failed for #{sql.inspect}: #{out}" unless $?.success?
+    out.strip
+  end
+
+  def reset_db(name)
+    `psql -U postgres -d postgres -c "DROP DATABASE IF EXISTS #{name} WITH (FORCE)" 2>&1`
+    `psql -U postgres -d postgres -c "CREATE DATABASE #{name}" 2>&1`
+    raise "could not create db #{name}" unless $?.success?
+  end
+
+  # Build a minimal, dependency-free cookbook tree containing ONLY the real
+  # pg_extension resource plus stubs for what its action include_recipe's/calls,
+  # then converge `recipe_body` against it. Returns the chef-solo output.
+  def converge(recipe_body, node_attrs)
+    Dir.mktmpdir("pgext-int") do |work|
+      cb = File.join(work, "cookbooks")
+      FileUtils.mkdir_p([
+        File.join(cb, "ey-postgresql", "resources"),
+        File.join(cb, "ey-postgresql", "recipes"),
+        File.join(cb, "ey-postgresql", "libraries"),
+        File.join(cb, "custom", "recipes"),
+      ])
+
+      FileUtils.cp(RESOURCE, File.join(cb, "ey-postgresql", "resources", "pg_extension.rb"))
+      File.write(File.join(cb, "ey-postgresql", "metadata.rb"), %(name "ey-postgresql"\nversion "0.0.0"\n))
+      %w[postgis_build auto_explain pg_stat_statements].each do |r|
+        File.write(File.join(cb, "ey-postgresql", "recipes", "#{r}.rb"), "# stub for integration test\n")
+      end
+      File.write(File.join(cb, "ey-postgresql", "libraries", "version_helpers.rb"), <<~RB)
+        class Chef
+          class Resource
+            def postgres_version_lt?(_); false; end
+            def postgres_version_gt?(_); false; end
+          end
+        end
+      RB
+
+      File.write(File.join(cb, "custom", "metadata.rb"), %(name "custom"\nversion "0.0.0"\ndepends "ey-postgresql"\n))
+      File.write(File.join(cb, "custom", "recipes", "default.rb"), recipe_body)
+
+      File.write(File.join(work, "solo.rb"), %(cookbook_path "#{cb}"\n))
+      File.write(File.join(work, "node.json"), JSON.dump(node_attrs.merge("run_list" => ["recipe[custom::default]"])))
+
+      out = `chef-solo -c #{File.join(work, "solo.rb").inspect} -j #{File.join(work, "node.json").inspect} --chef-license accept 2>&1`
+      out
+    end
+  end
+
+  # Chef embeds the entire node object into error output, which is megabytes of
+  # noise. Keep only the human-relevant lines for assertion messages.
+  def summarize(out)
+    out.each_line.grep(/error|fail|NameError|uninitialized|syntax|psql|action install/i)
+       .map { |l| l.strip[0, 200] }
+       .first(15)
+       .join("\n")
+  end
+
+  # Extract the real "process extensions.json" ruby_block from server_configure.rb
+  # so the dynamic-construction path is tested against the actual shipped code.
+  def extensions_json_block
+    src = File.read(SERVER_CONFIGURE)
+    block = src[/ruby_block "process extensions\.json".*?\n^end$/m]
+    raise "could not extract 'process extensions.json' block from server_configure.rb" unless block
+    block
+  end
+
+  BASE_NODE = {
+    "dna" => { "instance_role" => "db_master" },
+    "postgresql" => { "short_version" => "18" },
+    "pg_ext_details" => { "postgis" => {}, "hstore" => {}, "pg_trgm" => {} },
+    "engineyard" => { "environment" => { "ssh_username" => "postgres" } },
+    "postgis" => { "package_name" => "x" },
+  }.freeze
+end
+
+class PgExtensionIntegrationTest < Minitest::Test
+  H = PgExtHarness
+
+  # Assert `out` does not contain `pattern`, WITHOUT dumping chef's multi-megabyte
+  # node object (which refute_match would echo). Show only summarized error lines.
+  def refute_output(pattern, out, msg)
+    assert_nil(out[pattern], "#{msg}\n#{H.summarize(out)}")
+  end
+
+  def refute_name_error(out)
+    refute_output(/NameError/, out, "converge raised NameError (GHI-21914 regression):")
+  end
+
+  # Fix 1a: original reported case — single-string ext_name/db_name.
+  def test_single_string_creates_extension
+    H.reset_db("svcy")
+    out = H.converge(<<~RB, H::BASE_NODE)
+      ey_postgresql_pg_extension 'Get hstore' do
+        ext_name 'hstore'
+        db_name  'svcy'
+      end
+    RB
+    refute_name_error(out)
+    assert_equal "hstore", H.psql("SELECT extname FROM pg_extension WHERE extname='hstore'", db: "svcy"),
+                 "hstore should be installed in svcy"
+  end
+
+  # Fix 1b: the Array-typed property path (properties are [String, Array]).
+  # Must create every extension in every database.
+  def test_array_values_create_all_combinations
+    H.reset_db("svcy")
+    H.reset_db("other")
+    out = H.converge(<<~RB, H::BASE_NODE)
+      ey_postgresql_pg_extension 'multi' do
+        ext_name ['hstore', 'pg_trgm']
+        db_name  ['svcy', 'other']
+      end
+    RB
+    refute_name_error(out)
+    %w[svcy other].each do |db|
+      count = H.psql("SELECT count(*) FROM pg_extension WHERE extname IN ('hstore','pg_trgm')", db: db)
+      assert_equal "2", count, "both hstore and pg_trgm should be installed in #{db}"
+    end
+  end
+
+  # Fix 2: VERSION/FROM must be SQL-quoted. Unquoted `VERSION 1.4` was a syntax error.
+  def test_pinned_version_and_schema
+    H.reset_db("svcy")
+    H.psql("CREATE SCHEMA IF NOT EXISTS ext", db: "svcy")
+    version = H.psql("SELECT version FROM pg_available_extension_versions WHERE name='hstore' ORDER BY version LIMIT 1", db: "svcy")
+    skip "no hstore versions available" if version.empty?
+    out = H.converge(<<~RB, H::BASE_NODE)
+      ey_postgresql_pg_extension 'Get hstore' do
+        ext_name    'hstore'
+        db_name     'svcy'
+        schema_name 'ext'
+        version     '#{version}'
+      end
+    RB
+    refute_name_error(out)
+    refute_output(/syntax error/, out, "CREATE EXTENSION must not produce a SQL syntax error (VERSION must be quoted):")
+    assert_equal version, H.psql("SELECT extversion FROM pg_extension WHERE extname='hstore'", db: "svcy"),
+                 "hstore should be pinned to #{version}"
+    assert_equal "ext", H.psql("SELECT n.nspname FROM pg_extension e JOIN pg_namespace n ON n.oid=e.extnamespace WHERE extname='hstore'", db: "svcy"),
+                 "hstore should be created in schema ext"
+  end
+
+  # Fix 3: the real "process extensions.json" block must resolve the resource
+  # (declare_resource) and create the extensions — no `uninitialized constant`.
+  def test_extensions_json_dynamic_path
+    H.reset_db("svcy")
+    Dir.mktmpdir("pgext-json") do |dir|
+      ext_file = File.join(dir, "extensions.json")
+      File.write(ext_file, JSON.dump("svcy" => %w[hstore pg_trgm]))
+      node = H::BASE_NODE.merge("pg_extensions_file" => ext_file)
+      out = H.converge(H.extensions_json_block, node)
+      refute_name_error(out)
+      refute_output(/uninitialized constant/, out,
+                    "process extensions.json must not reference a stale resource constant:")
+      count = H.psql("SELECT count(*) FROM pg_extension WHERE extname IN ('hstore','pg_trgm')", db: "svcy")
+      assert_equal "2", count, "both extensions from extensions.json should be installed in svcy"
+    end
+  end
+end

--- a/cookbooks/ey-postgresql/spec/pg_extension_integration_test.rb
+++ b/cookbooks/ey-postgresql/spec/pg_extension_integration_test.rb
@@ -36,6 +36,7 @@ module PgExtHarness
   SPEC_DIR = __dir__
   EYPG_DIR = File.expand_path("..", SPEC_DIR)                       # cookbooks/ey-postgresql
   RESOURCE = File.join(EYPG_DIR, "resources", "pg_extension.rb")
+  CREATEDB = File.join(EYPG_DIR, "resources", "createdb.rb")
   SERVER_CONFIGURE = File.join(EYPG_DIR, "recipes", "server_configure.rb")
 
   module_function
@@ -66,6 +67,7 @@ module PgExtHarness
       ])
 
       FileUtils.cp(RESOURCE, File.join(cb, "ey-postgresql", "resources", "pg_extension.rb"))
+      FileUtils.cp(CREATEDB, File.join(cb, "ey-postgresql", "resources", "createdb.rb"))
       File.write(File.join(cb, "ey-postgresql", "metadata.rb"), %(name "ey-postgresql"\nversion "0.0.0"\n))
       %w[postgis_build auto_explain pg_stat_statements].each do |r|
         File.write(File.join(cb, "ey-postgresql", "recipes", "#{r}.rb"), "# stub for integration test\n")
@@ -182,6 +184,29 @@ class PgExtensionIntegrationTest < Minitest::Test
                  "hstore should be pinned to #{version}"
     assert_equal "ext", H.psql("SELECT n.nspname FROM pg_extension e JOIN pg_namespace n ON n.oid=e.extnamespace WHERE extname='hstore'", db: "svcy"),
                  "hstore should be created in schema ext"
+  end
+
+  # Fix 4: the sibling `createdb` resource had the same bare-property bug
+  # (db_name/owner read as bare identifiers; note db_name was not even a declared
+  # property — the DB name property is `name`). A customer-cookbook-style
+  # invocation must create the database, no NameError.
+  def test_createdb_creates_database
+    H.psql("DROP DATABASE IF EXISTS createdb_spec WITH (FORCE)", db: "postgres")
+    H.psql("DROP ROLE IF EXISTS deploy", db: "postgres")
+    H.psql("CREATE ROLE deploy LOGIN", db: "postgres")
+    out = H.converge(<<~RB, H::BASE_NODE)
+      createdb 'make app db' do
+        name  'createdb_spec'
+        owner 'deploy'
+      end
+    RB
+    refute_name_error(out)
+    assert_equal "1",
+                 H.psql("SELECT 1 FROM pg_database WHERE datname='createdb_spec'", db: "postgres"),
+                 "createdb should create the database createdb_spec"
+    assert_equal "deploy",
+                 H.psql("SELECT pg_catalog.pg_get_userbyid(datdba) FROM pg_database WHERE datname='createdb_spec'", db: "postgres"),
+                 "createdb should set the owner to deploy"
   end
 
   # Fix 3: the real "process extensions.json" block must resolve the resource

--- a/cookbooks/ey-postgresql/spec/pg_extension_regression.sh
+++ b/cookbooks/ey-postgresql/spec/pg_extension_regression.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Regression guard for GHI-21914 — pg_extension NameError under Chef 17.
+#
+# Converges the ey-postgresql `pg_extension` custom resource with Chef Infra
+# Client (Chef 17-compatible) using the customer's exact invocation (single
+# string values) plus the array form, and FAILS if the run raises `NameError`
+# for a resource property — the original bug, where `action :install` read its
+# properties as bare locals instead of `new_resource.*`.
+#
+# A running PostgreSQL is NOT required: the converge legitimately stops at the
+# psql step with a connection error, which this guard ignores. Only a NameError
+# (or failing to reach the resource) fails the guard.
+#
+# Requires chef-solo on PATH:  gem install chef chef-bin
+# Exit 0 = pass, 1 = regression, 2 = harness/setup error.
+set -uo pipefail
+
+SPEC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EYPG="$(cd "$SPEC_DIR/.." && pwd)"                 # cookbooks/ey-postgresql
+RES="$EYPG/resources/pg_extension.rb"
+[ -f "$RES" ] || { echo "cannot find $RES" >&2; exit 2; }
+command -v chef-solo >/dev/null || { echo "chef-solo not on PATH (gem install chef chef-bin)" >&2; exit 2; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+CB="$WORK/cookbooks"
+mkdir -p "$CB/ey-postgresql/resources" "$CB/ey-postgresql/recipes" \
+         "$CB/ey-postgresql/libraries" "$CB/custom/recipes"
+
+# Minimal, dependency-free ey-postgresql containing ONLY the resource under test
+# plus stubs for what its action include_recipe's / calls. This isolates the
+# property-access path from the full cookbook's unrelated dependencies.
+cp "$RES" "$CB/ey-postgresql/resources/pg_extension.rb"
+cat > "$CB/ey-postgresql/metadata.rb" <<'RB'
+name "ey-postgresql"
+version "0.0.0"
+RB
+: > "$CB/ey-postgresql/recipes/postgis_build.rb"
+: > "$CB/ey-postgresql/recipes/auto_explain.rb"
+: > "$CB/ey-postgresql/recipes/pg_stat_statements.rb"
+cat > "$CB/ey-postgresql/libraries/spec_regression_helpers.rb" <<'RB'
+class Chef
+  class Resource
+    def postgres_version_lt?(_); false; end
+    def postgres_version_gt?(_); false; end
+  end
+end
+RB
+
+cat > "$CB/custom/metadata.rb" <<'RB'
+name "custom"
+version "0.0.0"
+depends "ey-postgresql"
+RB
+cat > "$CB/custom/recipes/default.rb" <<'RB'
+ey_postgresql_pg_extension 'Get PostGIS' do
+  ext_name 'postgis'
+  db_name  'svcy'
+end
+
+ey_postgresql_pg_extension 'multi' do
+  ext_name ['postgis', 'hstore']
+  db_name  ['svcy', 'other']
+end
+RB
+
+cat > "$WORK/solo.rb"  <<RB
+cookbook_path "$CB"
+RB
+cat > "$WORK/node.json" <<'RB'
+{
+  "dna": { "instance_role": "db_master" },
+  "postgresql": { "short_version": "18" },
+  "pg_ext_details": { "postgis": {}, "hstore": {} },
+  "engineyard": { "environment": { "ssh_username": "postgres" } },
+  "postgis": { "package_name": "x" },
+  "run_list": ["recipe[custom::default]"]
+}
+RB
+
+OUT="$WORK/run.log"
+chef-solo -c "$WORK/solo.rb" -j "$WORK/node.json" --chef-license accept >"$OUT" 2>&1
+
+if ! grep -q "pg_extension\[Get PostGIS\] action install" "$OUT"; then
+  echo "ERROR: pg_extension resource never converged — harness problem:" >&2
+  tail -20 "$OUT" >&2
+  exit 2
+fi
+
+if grep -q "NameError" "$OUT"; then
+  echo "FAIL: pg_extension raised NameError (GHI-21914 regression):" >&2
+  grep -m1 "undefined local variable or method" "$OUT" | sed 's/ for #.*//' >&2
+  exit 1
+fi
+
+echo "PASS: pg_extension converged with no NameError (property reads are new_resource-qualified)"
+exit 0

--- a/cookbooks/ey-postgresql/spec/pg_extension_regression.sh
+++ b/cookbooks/ey-postgresql/spec/pg_extension_regression.sh
@@ -2,14 +2,25 @@
 # Regression guard for GHI-21914 — pg_extension NameError under Chef 17.
 #
 # Converges the ey-postgresql `pg_extension` custom resource with Chef Infra
-# Client (Chef 17-compatible) using the customer's exact invocation (single
-# string values) plus the array form, and FAILS if the run raises `NameError`
-# for a resource property — the original bug, where `action :install` read its
+# Client (Chef 17-compatible) and FAILS if the run raises `NameError` for a
+# resource property — the original bug, where `action :install` read its
 # properties as bare locals instead of `new_resource.*`.
 #
-# A running PostgreSQL is NOT required: the converge legitimately stops at the
+# The single-string and Array-typed invocations are converged as SEPARATE runs.
+# This matters without a database: the first resource's psql step fails (no DB)
+# and aborts the converge, so a single recipe with both resources would never
+# reach the second. Running them independently guarantees the property-access
+# path of BOTH the String and Array forms is actually exercised. Each run also
+# asserts its resource's action was reached, so a converge that dies early is a
+# harness error (exit 2), never a silent pass.
+#
+# A running PostgreSQL is NOT required: each converge legitimately stops at the
 # psql step with a connection error, which this guard ignores. Only a NameError
 # (or failing to reach the resource) fails the guard.
+#
+# For full database-state coverage (extension actually created, VERSION quoting,
+# the server_configure.rb dynamic path) run pg_extension_integration_test.rb
+# against a live PostgreSQL. This script is the fast, dependency-light gate.
 #
 # Requires chef-solo on PATH:  gem install chef chef-bin
 # Exit 0 = pass, 1 = regression, 2 = harness/setup error.
@@ -52,19 +63,8 @@ name "custom"
 version "0.0.0"
 depends "ey-postgresql"
 RB
-cat > "$CB/custom/recipes/default.rb" <<'RB'
-ey_postgresql_pg_extension 'Get PostGIS' do
-  ext_name 'postgis'
-  db_name  'svcy'
-end
 
-ey_postgresql_pg_extension 'multi' do
-  ext_name ['postgis', 'hstore']
-  db_name  ['svcy', 'other']
-end
-RB
-
-cat > "$WORK/solo.rb"  <<RB
+cat > "$WORK/solo.rb" <<RB
 cookbook_path "$CB"
 RB
 cat > "$WORK/node.json" <<'RB'
@@ -78,20 +78,42 @@ cat > "$WORK/node.json" <<'RB'
 }
 RB
 
-OUT="$WORK/run.log"
-chef-solo -c "$WORK/solo.rb" -j "$WORK/node.json" --chef-license accept >"$OUT" 2>&1
+# Converge one recipe body and check its resource reached `action install`
+# without a NameError. Args: <label> <resource-name-in-log> <recipe-body>
+run_case() {
+  local label="$1" res_name="$2" recipe="$3"
+  printf '%s\n' "$recipe" > "$CB/custom/recipes/default.rb"
+  local out="$WORK/${label}.log"
+  chef-solo -c "$WORK/solo.rb" -j "$WORK/node.json" --chef-license accept >"$out" 2>&1
 
-if ! grep -q "pg_extension\[Get PostGIS\] action install" "$OUT"; then
-  echo "ERROR: pg_extension resource never converged — harness problem:" >&2
-  tail -20 "$OUT" >&2
-  exit 2
+  if ! grep -q "pg_extension\[${res_name}\] action install" "$out"; then
+    echo "ERROR [$label]: pg_extension resource never converged — harness problem:" >&2
+    tail -20 "$out" >&2
+    return 2
+  fi
+  if grep -q "NameError" "$out"; then
+    echo "FAIL [$label]: pg_extension raised NameError (GHI-21914 regression):" >&2
+    grep -m1 "undefined local variable or method" "$out" | sed 's/ for #.*//' >&2
+    return 1
+  fi
+  echo "  ok [$label]: reached action install with no NameError"
+  return 0
+}
+
+rc=0
+run_case "single" "Get PostGIS" \
+"ey_postgresql_pg_extension 'Get PostGIS' do
+  ext_name 'postgis'
+  db_name  'svcy'
+end" || rc=$?
+
+run_case "array" "multi" \
+"ey_postgresql_pg_extension 'multi' do
+  ext_name ['postgis', 'hstore']
+  db_name  ['svcy', 'other']
+end" || rc=$?
+
+if [ "$rc" -eq 0 ]; then
+  echo "PASS: pg_extension property reads are new_resource-qualified (String + Array forms)"
 fi
-
-if grep -q "NameError" "$OUT"; then
-  echo "FAIL: pg_extension raised NameError (GHI-21914 regression):" >&2
-  grep -m1 "undefined local variable or method" "$OUT" | sed 's/ for #.*//' >&2
-  exit 1
-fi
-
-echo "PASS: pg_extension converged with no NameError (property reads are new_resource-qualified)"
-exit 0
+exit "$rc"

--- a/cookbooks/ey-postgresql/spec/pg_extension_regression.sh
+++ b/cookbooks/ey-postgresql/spec/pg_extension_regression.sh
@@ -1,26 +1,33 @@
 #!/usr/bin/env bash
-# Regression guard for GHI-21914 — pg_extension NameError under Chef 17.
+# Regression guard for GHI-21914 — Chef-17 bare-property NameError in the
+# ey-postgresql custom resources.
 #
-# Converges the ey-postgresql `pg_extension` custom resource with Chef Infra
-# Client (Chef 17-compatible) and FAILS if the run raises `NameError` for a
-# resource property — the original bug, where `action :install` read its
-# properties as bare locals instead of `new_resource.*`.
+# Under Chef 17's custom-resource action DSL, reading a declared property as a
+# bare identifier (not qualified with `new_resource.`) raises
+# `NameError: undefined local variable or method '<prop>'` deterministically on
+# every invocation. This bit two EY-authored public resources that customer
+# cookbooks call directly:
+#   - pg_extension (action :install)      — the originally reported defect
+#   - createdb     (action :createdb_action) — same bug class, same customer-
+#                                              cookbook trigger vector
 #
-# The single-string and Array-typed invocations are converged as SEPARATE runs.
-# This matters without a database: the first resource's psql step fails (no DB)
-# and aborts the converge, so a single recipe with both resources would never
-# reach the second. Running them independently guarantees the property-access
-# path of BOTH the String and Array forms is actually exercised. Each run also
-# asserts its resource's action was reached, so a converge that dies early is a
-# harness error (exit 2), never a silent pass.
+# This guard converges each resource with Chef Infra Client (Chef 17-compatible)
+# and FAILS if the run raises `NameError` for a property. The pg_extension
+# String and Array forms are converged as SEPARATE runs: without a database the
+# first resource's psql step aborts the converge, so a single recipe with both
+# would never reach the second. Running them independently guarantees each
+# property-access path is actually exercised. Each run also asserts its
+# resource's action was reached, so a converge that dies early is a harness
+# error (exit 2), never a silent pass.
 #
 # A running PostgreSQL is NOT required: each converge legitimately stops at the
 # psql step with a connection error, which this guard ignores. Only a NameError
 # (or failing to reach the resource) fails the guard.
 #
-# For full database-state coverage (extension actually created, VERSION quoting,
-# the server_configure.rb dynamic path) run pg_extension_integration_test.rb
-# against a live PostgreSQL. This script is the fast, dependency-light gate.
+# For full database-state coverage (extension/database actually created, VERSION
+# quoting, the server_configure.rb dynamic path) run
+# pg_extension_integration_test.rb against a live PostgreSQL. This script is the
+# fast, dependency-light gate.
 #
 # Requires chef-solo on PATH:  gem install chef chef-bin
 # Exit 0 = pass, 1 = regression, 2 = harness/setup error.
@@ -28,8 +35,9 @@ set -uo pipefail
 
 SPEC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EYPG="$(cd "$SPEC_DIR/.." && pwd)"                 # cookbooks/ey-postgresql
-RES="$EYPG/resources/pg_extension.rb"
-[ -f "$RES" ] || { echo "cannot find $RES" >&2; exit 2; }
+for f in resources/pg_extension.rb resources/createdb.rb; do
+  [ -f "$EYPG/$f" ] || { echo "cannot find $EYPG/$f" >&2; exit 2; }
+done
 command -v chef-solo >/dev/null || { echo "chef-solo not on PATH (gem install chef chef-bin)" >&2; exit 2; }
 
 WORK="$(mktemp -d)"
@@ -38,10 +46,11 @@ CB="$WORK/cookbooks"
 mkdir -p "$CB/ey-postgresql/resources" "$CB/ey-postgresql/recipes" \
          "$CB/ey-postgresql/libraries" "$CB/custom/recipes"
 
-# Minimal, dependency-free ey-postgresql containing ONLY the resource under test
-# plus stubs for what its action include_recipe's / calls. This isolates the
-# property-access path from the full cookbook's unrelated dependencies.
-cp "$RES" "$CB/ey-postgresql/resources/pg_extension.rb"
+# Minimal, dependency-free ey-postgresql containing ONLY the resources under
+# test plus stubs for what their actions include_recipe / call. This isolates
+# the property-access path from the full cookbook's unrelated dependencies.
+cp "$EYPG/resources/pg_extension.rb" "$CB/ey-postgresql/resources/pg_extension.rb"
+cp "$EYPG/resources/createdb.rb"     "$CB/ey-postgresql/resources/createdb.rb"
 cat > "$CB/ey-postgresql/metadata.rb" <<'RB'
 name "ey-postgresql"
 version "0.0.0"
@@ -78,42 +87,52 @@ cat > "$WORK/node.json" <<'RB'
 }
 RB
 
-# Converge one recipe body and check its resource reached `action install`
-# without a NameError. Args: <label> <resource-name-in-log> <recipe-body>
+# Converge one recipe body and check its resource reached its action without a
+# NameError. Args: <label> <converged-line-substring> <recipe-body>
+#   <converged-line-substring> e.g. "pg_extension[Get PostGIS] action install"
 run_case() {
-  local label="$1" res_name="$2" recipe="$3"
+  local label="$1" converged="$2" recipe="$3"
   printf '%s\n' "$recipe" > "$CB/custom/recipes/default.rb"
   local out="$WORK/${label}.log"
   chef-solo -c "$WORK/solo.rb" -j "$WORK/node.json" --chef-license accept >"$out" 2>&1
 
-  if ! grep -q "pg_extension\[${res_name}\] action install" "$out"; then
-    echo "ERROR [$label]: pg_extension resource never converged — harness problem:" >&2
+  if ! grep -qF "$converged" "$out"; then
+    echo "ERROR [$label]: resource never converged — harness problem:" >&2
     tail -20 "$out" >&2
     return 2
   fi
   if grep -q "NameError" "$out"; then
-    echo "FAIL [$label]: pg_extension raised NameError (GHI-21914 regression):" >&2
+    echo "FAIL [$label]: raised NameError (GHI-21914 regression):" >&2
     grep -m1 "undefined local variable or method" "$out" | sed 's/ for #.*//' >&2
     return 1
   fi
-  echo "  ok [$label]: reached action install with no NameError"
+  echo "  ok [$label]: reached action with no NameError"
   return 0
 }
 
 rc=0
-run_case "single" "Get PostGIS" \
+run_case "pg_extension-single" "pg_extension[Get PostGIS] action install" \
 "ey_postgresql_pg_extension 'Get PostGIS' do
   ext_name 'postgis'
   db_name  'svcy'
 end" || rc=$?
 
-run_case "array" "multi" \
+run_case "pg_extension-array" "pg_extension[multi] action install" \
 "ey_postgresql_pg_extension 'multi' do
   ext_name ['postgis', 'hstore']
   db_name  ['svcy', 'other']
 end" || rc=$?
 
+# createdb: same bug class, invoked the way a customer cookbook would.
+# (The `name` property overrides the resource block string, so the converged
+# line shows createdb[svcy], not createdb[make db].)
+run_case "createdb" "createdb[svcy] action createdb_action" \
+"createdb 'make db' do
+  name  'svcy'
+  owner 'deploy'
+end" || rc=$?
+
 if [ "$rc" -eq 0 ]; then
-  echo "PASS: pg_extension property reads are new_resource-qualified (String + Array forms)"
+  echo "PASS: pg_extension and createdb property reads are new_resource-qualified"
 fi
 exit "$rc"


### PR DESCRIPTION
## Issue
Related to trilogy-group/eng-maintenance#21914

## Summary
The `pg_extension` v7 custom resource crashed with `NameError: undefined local variable or method 'ext_name'` under Chef 17, blocking normal Apply on any v7 environment whose custom cookbook uses `pg_extension` (e.g. to install PostGIS). This qualifies the resource's property reads with `new_resource.` so the action runs correctly.

## Root Cause
`action :install` read its declared properties (`ext_name`, `db_name`, `use_load`, `schema_name`, `version`, `old_version`) as bare identifiers. Chef 17's custom-resource action DSL does not expose properties as bare locals/methods inside `action` blocks — only `new_resource.<property>` is a valid accessor there. The very first bare read (`ext_name`, line 13) therefore raised `NameError` on every invocation, independent of the extension/database values.

## Changes Made
`cookbooks/ey-postgresql/resources/pg_extension.rb` — qualified every property read inside `action :install` with `new_resource.`:
- Line 13: `ext_name` → `new_resource.ext_name`
- Line 14: `db_name` → `new_resource.db_name`
- Line 34: `use_load` → `new_resource.use_load`
- Line 43: `schema_name`, `version`, `old_version` → `new_resource.schema_name` / `new_resource.version` / `new_resource.old_version`

`ext_name`/`db_name` references inside the `.each` blocks are loop-local variables (shadowing the property name) and are intentionally left unqualified — they are correct Ruby block-locals, not property accessors.

## Testing Plan
- Reproduced the original failure locally with **Chef Infra Client 17.9.46** (the exact production version) using the customer's exact recipe (`pg_extension 'Get PostGIS' do ext_name 'postgis'; db_name 'svcy'; end`) against the unpatched resource — got the identical `NameError` at `pg_extension.rb:13`.
- Re-ran the same reproduction against the **patched** resource file: **zero `NameError`s**; execution advances into the `execute` resource running the actual `psql CREATE EXTENSION` (only remaining failure is "no local Postgres server", an environment limitation, not a code defect).
- Validated **array** `ext_name`/`db_name` values (`['postgis','hstore']` / `['svcy','other']`) also run without `NameError` and iterate the `.each` loops correctly.
- Recommended follow-up: normal UI Apply on `pgprod` (currently still reproduces the bug) with the released stack containing this fix, confirming PostGIS installs via `pg_extension` without the temporary cached-Chef workaround.

## Documentation
- [Verification Report](https://github.com/trilogy-group/eng-maintenance/issues/21914#issuecomment-4913640623)
- [RCA Report](https://github.com/trilogy-group/eng-maintenance/issues/21914#issuecomment-4913709663)
